### PR TITLE
fix(ci): prepare WXT before typecheck

### DIFF
--- a/openspec/changes/repair-wxt-typecheck-readiness/.openspec.yaml
+++ b/openspec/changes/repair-wxt-typecheck-readiness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/repair-wxt-typecheck-readiness/design.md
+++ b/openspec/changes/repair-wxt-typecheck-readiness/design.md
@@ -1,0 +1,83 @@
+## Context
+
+At clean `develop@b140b68dc8b2635e95ade977dfa504c94b7663c2`, root `package.json` defines `check` as `tsc --noEmit` and `postinstall` as `wxt prepare`. The CI linter job installs dependencies, runs formatter/linter fixes plus `git diff --exit-code`, and then runs `pnpm run check`. A restored dependency tree does not guarantee that the current checkout's ignored `.wxt/tsconfig.json` exists or that the root lifecycle regenerated it.
+
+The independent Archify PR #73 has immutable head `5ee76d1a195f26958e0866df87aa97ece4e28a22`. Its fresh CI and the current `develop` CI both fail type checking with the same missing generated WXT environment and unresolved `#imports`/existing `@/...` aliases. The Archify exact does not touch the affected root WXT/TypeScript contract, so it must stay frozen while the base is repaired separately.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the canonical TypeScript gate self-contained in fresh and cache-restored environments.
+- Preserve strict `tsc --noEmit` behavior and existing aliases.
+- Keep one local/CI entry point and one minimal source delta.
+- Preserve ignored generated-output ownership.
+- Unblock an exact-bound CI rerun for the unchanged Archify head after the base repair lands.
+
+**Non-Goals:**
+
+- Workflow or dependency-cache redesign.
+- TypeScript config relaxation, import rewrites, source changes, dependency updates, or committed `.wxt` output.
+- Any Archify, Runtime, protocol, persistence, product, browser, or UI change.
+- Any merge or release decision.
+
+## Decisions
+
+### 1. The canonical check script owns WXT preparation
+
+Root `package.json` SHALL define the exact script:
+
+```json
+"check": "wxt prepare && tsc --noEmit"
+```
+
+The left side creates the checkout-specific ignored WXT TypeScript environment; shell short-circuiting ensures TypeScript runs only after successful preparation. The existing CI command `pnpm run check` therefore gains the same readiness behavior as a local invocation without a duplicated workflow-only sequence.
+
+Alternative rejected: add only a CI workflow step. That leaves local and other automation entry points dependent on hidden order and creates two typecheck contracts.
+
+Alternative rejected: depend only on `postinstall`. Cache restoration or an already-installed dependency tree can leave the current checkout without generated WXT state.
+
+### 2. Keep postinstall but treat it as an optimization, not authority
+
+The existing `postinstall: wxt prepare` MAY remain unchanged for normal installation ergonomics. It does not satisfy or replace the check script's own preparation requirement.
+
+Alternative rejected: remove `postinstall` in this repair. Its broader developer/build implications are unnecessary to resolve the gate.
+
+### 3. Generated WXT state remains disposable and untracked
+
+`.wxt/**` remains ignored and SHALL NOT enter the commit, cache key authority, or review surface. Verification deletes or starts without `.wxt`, runs the canonical check, proves `.wxt/tsconfig.json` was created, and confirms the tracked worktree remains clean.
+
+Alternative rejected: commit `.wxt/tsconfig.json`. It is generated checkout state and would couple source history to WXT output.
+
+### 4. Preserve failure semantics and quality gates
+
+If `wxt prepare` fails, the gate fails without running TypeScript. If `tsc --noEmit` finds a real error, that error remains visible and fails the gate. No skip, waiver, alias rewrite, error suppression, or `continue-on-error` is allowed. Existing format/lint fix-plus-diff behavior and Chrome/Firefox build gates remain unchanged.
+
+### 5. Keep remediation and publication histories independent
+
+The implementation candidate is a sole child of clean `develop@b140b68...` with exactly root `package.json` as its non-OpenSpec source/config delta. It is reviewed, pushed, and proposed through its own PR. It must not amend, rebase, merge into, or become part of the immutable Archify head or Runtime ancestry.
+
+After explicit Owner authorization merges the base repair into `develop`, PR #73 keeps head `5ee76d1...` unchanged and receives a fresh CI run against the repaired base. PR #73 merge remains a separate explicit Owner decision.
+
+## Risks / Trade-offs
+
+- [Preparation adds time to every typecheck] -> Accept the small deterministic cost in exchange for a self-contained gate.
+- [WXT preparation changes ignored files] -> Assert `.wxt` remains ignored and tracked diff stays clean across repeated checks.
+- [Preparation failure hides TypeScript output] -> This is intentional ordering; report the earlier causal failure rather than running against invalid generated state.
+- [A broader CI issue appears after this fix] -> Stop and report the new exact failure; do not widen this candidate.
+- [Archify PR is treated as fixed by inheritance alone] -> Require a fresh PR #73 CI run against the repaired `develop` base; no verdict transfers.
+
+## Migration Plan
+
+1. Freeze the clean `develop` identity and reproduce the current missing-`.wxt` failure without modifying source.
+2. Create a detached clean child and change only root `package.json` `check` to the exact frozen script.
+3. Starting without `.wxt`, run the canonical check twice and verify generated readiness, TypeScript success, and zero tracked diff.
+4. Run repository format/lint checks, OpenSpec strict validation, Chrome and Firefox builds, and diff/scope checks on the candidate.
+5. Freeze one immutable exact, route independent Reviewer validation, then push/open a separate base-remediation PR and run fresh exact-bound CI.
+6. Ask the Owner for explicit merge authorization only after all gates pass. After merge, rerun PR #73 CI against the repaired base without changing its head.
+
+Rollback is code-only: revert the one root script change. No user data, extension state, protocol, schema, or migration is involved.
+
+## Open Questions
+
+None. The repair is intentionally limited to making the existing strict typecheck gate establish its required WXT generated environment.

--- a/openspec/changes/repair-wxt-typecheck-readiness/proposal.md
+++ b/openspec/changes/repair-wxt-typecheck-readiness/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The `develop` CI typecheck can run after `node_modules` has been restored without a usable generated `.wxt/tsconfig.json`. The current `check` script invokes `tsc --noEmit` directly and therefore assumes that an earlier install lifecycle generated WXT's TypeScript environment. That hidden precondition makes the same repository exact fail with unresolved `#imports` and existing `@/...` aliases in CI.
+
+This inherited base failure also blocks the independent Archify PR even though its 55-path tooling delta does not touch WXT, TypeScript, application source, or the root workflow. The canonical typecheck gate must establish its own generated prerequisite so fresh and cache-restored environments behave the same.
+
+## What Changes
+
+- Make the canonical root `check` script run the installed WXT prepare command before `tsc --noEmit`.
+- Freeze the exact script contract as `wxt prepare && tsc --noEmit`.
+- Keep CI invoking `pnpm run check` so local and CI type checking use one self-contained gate.
+- Keep the existing `postinstall` WXT preparation, but do not rely on install lifecycle execution as the only typecheck prerequisite.
+- Keep `.wxt/**` generated, ignored, and uncommitted.
+- Deliver the repair as an independent clean-`develop` child and separate PR before re-running the unchanged Archify PR against the repaired base.
+
+## Capabilities
+
+### New Capabilities
+
+- `wxt-typecheck-readiness`: Self-contained WXT generation and TypeScript gate behavior across fresh and cache-restored environments.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Root `package.json` `check` script only for source implementation.
+- New OpenSpec authority files for this repair.
+- No application source, root workflow, dependency, lockfile, WXT configuration, generated `.wxt`, Archify, Runtime, protocol, persistence, browser behavior, or UI change.
+
+## Non-Goals
+
+- No TypeScript relaxation, alias rewrite, source import rewrite, skip, waiver, `continue-on-error`, or generated-file commit.
+- No dependency or WXT version change.
+- No cache redesign, CI workflow refactor, or unrelated quality-tooling change.
+- No amendment, rebase, or scope expansion of Archify exact `5ee76d1...` or Runtime PR #69.
+- No merge or release authorization.
+
+## Acceptance Criteria
+
+- With `.wxt` absent and installed dependencies present, `pnpm run check` first generates the WXT TypeScript environment and then passes `tsc --noEmit` on the unchanged base source.
+- A WXT prepare failure prevents TypeScript from running and fails the gate; a TypeScript failure remains visible and fails the gate.
+- Repeated `pnpm run check` calls are successful and do not create a tracked diff.
+- `.wxt/tsconfig.json` exists after preparation but `.wxt/**` remains ignored and absent from the candidate commit.
+- The source candidate is a clean, detached, unpushed, no-ref sole child of `develop@b140b68dc8b2635e95ade977dfa504c94b7663c2` whose production/config delta is exactly root `package.json`.
+- Fresh independent review and exact-bound CI pass before the base repair may be merged; merge requires explicit Owner authorization.

--- a/openspec/changes/repair-wxt-typecheck-readiness/specs/wxt-typecheck-readiness/spec.md
+++ b/openspec/changes/repair-wxt-typecheck-readiness/specs/wxt-typecheck-readiness/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Canonical TypeScript gate prepares WXT state
+
+The root `check` script SHALL be exactly `wxt prepare && tsc --noEmit`. The installed WXT prepare command SHALL settle successfully before strict TypeScript checking begins. CI and local automation SHALL invoke this canonical script rather than depend on an earlier install lifecycle as the only WXT-generation prerequisite.
+
+#### Scenario: Typecheck starts without generated WXT state
+
+- **WHEN** installed dependencies are present but `.wxt` is absent
+- **THEN** `pnpm run check` SHALL generate `.wxt/tsconfig.json` and then run `tsc --noEmit` successfully against the unchanged source
+
+#### Scenario: Typecheck starts with existing generated WXT state
+
+- **WHEN** `.wxt` already contains current generated state
+- **THEN** `pnpm run check` SHALL safely refresh that state and run the same strict TypeScript gate
+
+#### Scenario: WXT preparation fails
+
+- **WHEN** `wxt prepare` rejects or exits non-zero
+- **THEN** the canonical check SHALL fail immediately and SHALL NOT report a successful or independently executed TypeScript gate
+
+#### Scenario: TypeScript detects a real error
+
+- **WHEN** WXT preparation succeeds but `tsc --noEmit` reports a type error
+- **THEN** the canonical check SHALL fail with that error and SHALL NOT suppress, waive, or rewrite it
+
+### Requirement: Generated WXT state remains disposable
+
+`.wxt/**` SHALL remain ignored generated checkout state. The repair SHALL NOT commit `.wxt/tsconfig.json` or any other generated WXT file, and repeated canonical checks SHALL leave no tracked diff.
+
+#### Scenario: Review generated output ownership
+
+- **WHEN** `pnpm run check` creates or refreshes `.wxt`
+- **THEN** `.wxt/**` SHALL remain ignored, absent from the candidate commit, and removable before the next successful check
+
+#### Scenario: Repeat the canonical check
+
+- **WHEN** the canonical check is run twice on one unchanged checkout
+- **THEN** both runs SHALL pass and the second run SHALL leave the tracked worktree clean
+
+### Requirement: Install lifecycle is not the typecheck authority
+
+The existing `postinstall` WXT preparation MAY remain for installation ergonomics, but a successful or previously cached install SHALL NOT be treated as proof that the current checkout is ready for TypeScript. The canonical check SHALL establish readiness itself.
+
+#### Scenario: Dependencies are restored from cache
+
+- **WHEN** `node_modules` is restored or already present while the checkout has no `.wxt`
+- **THEN** `pnpm run check` SHALL not require lifecycle replay and SHALL prepare the current checkout before TypeScript
+
+### Requirement: Base remediation remains isolated
+
+The implementation SHALL be a clean `develop@b140b68dc8b2635e95ade977dfa504c94b7663c2` child whose only non-OpenSpec source/config change is root `package.json`. It SHALL NOT change the workflow, lockfile, dependency versions, TypeScript configuration, WXT configuration, application source, Archify files, Runtime files, protocol, persistence, browser behavior, or UI.
+
+#### Scenario: Inspect implementation scope
+
+- **WHEN** the candidate is compared with its clean `develop` parent
+- **THEN** the executable/config delta SHALL contain only the exact root `package.json` check-script change and SHALL contain no generated `.wxt` file
+
+#### Scenario: Encounter another CI failure
+
+- **WHEN** a fresh gate exposes a failure not caused by missing WXT preparation
+- **THEN** this candidate SHALL remain unchanged and the new failure SHALL be reported as a separate blocker rather than suppressed or folded into scope
+
+### Requirement: Publication gates remain exact-bound
+
+The base-remediation candidate SHALL pass independent review and fresh exact-bound CI before merge authorization is requested. Merging the base repair SHALL NOT transfer a PASS to the unchanged Archify head; PR #73 SHALL receive a fresh CI run against the repaired `develop` base. Each merge requires separate explicit Owner authorization.
+
+#### Scenario: Base remediation passes CI
+
+- **WHEN** the independent candidate reaches a successful exact-bound CI terminal state
+- **THEN** the team MAY ask the Owner for that base-remediation PR's merge authorization without authorizing Archify or Runtime merge
+
+#### Scenario: Re-evaluate Archify after base repair
+
+- **WHEN** the repaired base is merged into `develop`
+- **THEN** PR #73 SHALL retain exact head `5ee76d1a195f26958e0866df87aa97ece4e28a22` and run fresh CI against the new base before its own merge authorization can be requested

--- a/openspec/changes/repair-wxt-typecheck-readiness/tasks.md
+++ b/openspec/changes/repair-wxt-typecheck-readiness/tasks.md
@@ -1,0 +1,27 @@
+## 1. Baseline And FAIL-Before
+
+- [x] 1.1 Record clean `develop@b140b68dc8b2635e95ade977dfa504c94b7663c2` identity, tree, branch/ref state, workflow/package hashes, and the failed base/Archify CI run identities.
+- [x] 1.2 In a disposable clean checkout with installed dependencies and `.wxt` absent, run the unchanged `pnpm run check` twice and preserve the unresolved `#imports`/existing-alias FAIL-before plus tracked-clean status.
+- [x] 1.3 Prove the failure is absent from the 55 allowed Archify paths and do not transfer any Archify/Runtime verdict to this candidate.
+
+## 2. Minimal Repair
+
+- [x] 2.1 Create a detached clean child of `b140b68...` and change only root `package.json` `check` from `tsc --noEmit` to exact `wxt prepare && tsc --noEmit`.
+- [x] 2.2 Keep `postinstall`, `.gitignore`, workflow, lockfile, dependency versions, TypeScript/WXT config, application source, Archify, Runtime, protocol, persistence, browser, and UI bytes unchanged.
+- [x] 2.3 Add no generated `.wxt` path, skip, waiver, `continue-on-error`, alias rewrite, source workaround, or cache-specific branch.
+
+## 3. Candidate Verification
+
+- [x] 3.1 Remove ignored `.wxt`, run `pnpm run check`, and prove WXT creates `.wxt/tsconfig.json` before strict TypeScript passes.
+- [x] 3.2 Run the canonical check a second time and prove successful idempotence, zero tracked diff, and no committed `.wxt` file.
+- [x] 3.3 Prove failure propagation with a disposable WXT-prepare failure control and a disposable real TypeScript-error control without retaining fixture changes.
+- [x] 3.4 Run applicable format/lint fix-plus-diff and read-only checks, Chrome and Firefox production builds, OpenSpec target/all strict/status/doctor, and `git diff --check` on frozen inputs.
+- [x] 3.5 Freeze one clean, detached, unpushed, no-ref sole child with exact/tree/parent, one-path executable scope, patch hashes, fail-before/final evidence, and unchanged protected-input hashes; then STOP.
+
+## 4. Independent Review And Publication
+
+- [x] 4.1 Planner reviews only the requirements/decomposition authority; Planner does not issue a source verdict.
+- [ ] 4.2 Reviewer independently audits the frozen source exact, test sensitivity, one-path scope, failure propagation, unchanged gates, and evidence. Only `FINAL PASS` releases publication.
+- [ ] 4.3 Push the immutable exact on an independent branch, open a separate `develop`-base PR, and track fresh exact-bound CI to terminal success without merge.
+- [ ] 4.4 After successful review/CI, ask the Owner for explicit base-remediation merge authorization. Commit, push, and PR update require no separate authorization.
+- [ ] 4.5 After the repair merges to `develop`, keep PR #73 head exactly `5ee76d1a...`, run fresh CI against the repaired base, and keep Archify merge separately unauthorized until its own exact-bound gates and Owner decision.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "oxlint --fix .",
     "lint:check": "oxlint .",
     "clear": "rimraf .output node_modules",
-    "check": "tsc --noEmit",
+    "check": "wxt prepare && tsc --noEmit",
     "prepare": "husky",
     "postinstall": "wxt prepare"
   },


### PR DESCRIPTION
## Summary

- make the canonical `pnpm run check` prepare WXT's generated TypeScript environment before strict `tsc --noEmit`
- keep `.wxt/**` ignored and uncommitted
- add the approved OpenSpec authority for the isolated base-CI repair

## Scope

The sole executable/config change is:

```json
"check": "wxt prepare && tsc --noEmit"
```

Workflow, lockfile, dependencies, TypeScript/WXT config, application source, Runtime, protocol, persistence, UI, and Archify paths are unchanged.

## Verification

- two checks from absent `.wxt`: WXT prepare then TypeScript PASS
- prepare-failure short-circuit control PASS
- real TypeScript-error propagation control PASS
- format PASS; lint 0 errors (49 inherited warnings)
- OpenSpec strict target/all PASS, status 4/4, doctor PASS
- Chrome MV3 and Firefox MV2 production builds PASS
- exact scope/protected bytes/diff checks PASS

Candidate exact: `56ebff521299b3644d7bf3b2a4858958388e2918`
Evidence hash: `897af4a02f46519f2659f04ecda3910cf288b9413d0602e87e18e28a49165924`

This PR does not modify or authorize merge of Archify PR #73 or Runtime PR #69. Merge requires separate explicit Owner authorization.
