### PR TITLE
fix(content): run Firefox persistence preparation without Web Locks

### DIFF
--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/.openspec.yaml
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-08-01
+goal: Prepare versioned persistence reliably in Firefox without Web Locks and
+  terminate blocked IndexedDB deletion as a retryable initialization error.

--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/README.md
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/README.md
@@ -1,0 +1,3 @@
+# prepare-firefox-persistence-without-web-locks
+
+Use browser-appropriate persistence preparation while keeping one versioned storage contract.

--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/design.md
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/design.md
@@ -1,0 +1,47 @@
+## Context
+
+Content initialization prepares browser-sync configuration, origin-local configuration, and the per-origin message database before Runtime activation. The preparation lifecycle owns generation fencing, version checks, reset writes, and retry from persisted truth. Browser composition supplies the one coordination strategy used by the local-configuration and message-database stages.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep one persistence-preparation lifecycle and one version authority for each storage family.
+- Avoid the Firefox content-script Web Locks Promise boundary.
+- Use Chrome cross-context arbitration through Web Locks.
+- Give a blocked IndexedDB deletion one bounded terminal that reaches the initialization recovery surface.
+
+**Non-Goals:**
+
+- Adding a background lock service, alternate persistence owner, alternate format, browser-specific schema, or public API.
+- Changing current storage identities, version numbers, reset eligibility, clear/delete scope, or successful initialization behavior.
+- Adding a persistence-preparation panel, dialog, notification, success Toast, or close-tabs instruction.
+
+## Decisions
+
+### 1. Browser composition owns the coordinator choice
+
+The content entry selects one `PreparationLockCoordinator` from the WXT browser target. Firefox supplies direct acquisition, which returns an immediate release function and never reads `navigator.locks`. Chrome supplies the Web Locks coordinator. Storage implementations consume the injected coordinator and do not choose a browser or maintain parallel coordination state.
+
+### 2. Firefox converges through current versioned operations
+
+Direct Firefox preparation uses the generation owner, abort fencing, checkpoints, version reads, idempotent completion writes, and canonical storage boundaries. Concurrent tabs may execute the same current-version decision, but no tab introduces another version, identity, schema, or durable lock state. The settled storage version and current canonical data remain authoritative.
+
+### 3. Blocked IndexedDB deletion has a five-second terminal
+
+The first `blocked` event for canonical message-database deletion starts one five-second timer. Success or error clears that timer. If the request remains blocked at the deadline, the current preparation rejects with `Message store deletion blocked`; it does not report readiness or start a competing delete operation.
+
+### 4. Initialization feedback owns recovery
+
+A preparation rejection terminates only the current initialization attempt. The initialization owner marks the application unavailable and publishes the normalized generic `WebChat unavailable` error Toast. Actions-menu Refresh starts a later current attempt. Persistence preparation adds no separate retry state or dedicated user-facing copy.
+
+### 5. Verification binds source and production behavior
+
+Deterministic controls cover browser coordinator selection, no Firefox Web Locks call, Chrome Web Locks arbitration, concurrent direct convergence, generation fencing, and blocked deletion before, at, and after the deadline. Production Firefox verification covers current initialization and concurrent tabs; blocked-timeout browser evidence remains distinct from deterministic coverage and is never inferred from it.
+
+## Risks / Trade-offs
+
+- [Firefox tabs prepare concurrently] -> Keep operations versioned, idempotent, generation-fenced, and restricted to the canonical current storage identities.
+- [A live IndexedDB connection blocks deletion] -> Fail the current attempt after five seconds and expose the retryable initialization error instead of hanging.
+- [A late browser event follows the bounded terminal] -> It cannot turn the failed attempt into application readiness; only a later current initialization attempt may publish ready state.
+- [Browser selection drifts] -> Bind composition and regression coverage to WXT's production browser target and real Firefox/Chrome builds.

--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/proposal.md
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Firefox content scripts cannot safely assimilate the Promise returned by the Web Locks API. Persistence preparation therefore avoids Web Locks in Firefox, converges on the canonical current storage state, and produces a bounded, user-recoverable result when IndexedDB deletion remains blocked.
+
+## What Changes
+
+- Select persistence-preparation coordination at browser composition: Firefox runs the versioned preparation operation directly, while Chrome uses Web Locks arbitration.
+- Use the versioned message and configuration writes as the only persistence truth. Firefox has no second lock owner, background mutex, alternate storage path, or alternate format.
+- Bound an IndexedDB version-reset deletion that reports `blocked`: if it does not settle within five seconds, the current initialization attempt fails instead of waiting forever.
+- Route that terminal failure through the initialization state and generic error Toast so actions-menu Refresh can start a new current attempt.
+- Preserve the current storage identities, versions, reset semantics, public ports, browser permissions, Runtime behavior, and user data boundaries.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `webrtc-runtime`: Define browser-specific persistence-preparation coordination and the bounded blocked-deletion terminal.
+
+## Impact
+
+- Affected behavior: content initialization that prepares local configuration and the IndexedDB message database in Firefox and Chrome.
+- Affected implementation: persistence coordinator composition, versioned storage preparation, and IndexedDB deletion settlement.
+- Affected verification: Firefox direct preparation, Chrome Web Locks preparation, concurrent convergence, blocked deletion, Retry, and browser-bound production initialization.
+- Outside this change: stored schemas and identities, reset eligibility, protocol, message semantics, public APIs, dependencies, permissions, Runtime topology, and unrelated browser behavior.

--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/specs/webrtc-runtime/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Persistence preparation uses the browser-appropriate coordinator
+
+The content initialization composition SHALL provide one coordination strategy to origin-local configuration preparation and canonical message-database preparation. Firefox MV2 SHALL use direct preparation and SHALL NOT call, await, or require `navigator.locks`. Chrome MV3 SHALL use Web Locks arbitration for those same preparation stages.
+
+Both strategies SHALL use the same storage identities, versions, reset eligibility, generation fencing, abort behavior, checkpoints, and versioned writes. Firefox direct preparation SHALL use no durable lock record, background mutex, alternate schema, or second persistence owner. A current successful preparation SHALL publish the same ready result on both browsers.
+
+#### Scenario: Firefox prepares without Web Locks
+
+- **GIVEN** the production Firefox MV2 content initialization owns current configuration and message-store preparation
+- **WHEN** those preparation stages execute
+- **THEN** they SHALL use the direct coordinator, SHALL perform no Web Locks request, and SHALL converge through the canonical current-version storage operations
+
+#### Scenario: Chrome uses Web Locks arbitration
+
+- **GIVEN** the production Chrome MV3 content initialization owns current configuration and message-store preparation
+- **WHEN** those preparation stages execute
+- **THEN** they SHALL acquire the namespaced Web Lock before the owned operation and release it after settlement
+
+#### Scenario: Concurrent Firefox tabs converge on current storage
+
+- **GIVEN** two Firefox content scripts prepare the same origin-local configuration and canonical message database concurrently
+- **WHEN** both direct preparation attempts settle
+- **THEN** the canonical storage SHALL expose the configured current versions and one consistent ready result without a second identity, schema, version authority, or persistent coordination state
+
+### Requirement: Blocked message-database deletion terminates as retryable initialization failure
+
+When deletion of the canonical IndexedDB message database for a version mismatch reports `blocked`, WebChat SHALL own one delete request and start one five-second blocked deadline. Success or error before the deadline SHALL clear that deadline and settle that request. If the request remains blocked at the deadline, the current preparation SHALL reject with `Message store deletion blocked`, SHALL NOT publish readiness, and SHALL NOT start a competing delete.
+
+The current initialization owner SHALL surface that rejection through its unavailable state and normalized generic error Toast. Actions-menu Refresh SHALL be eligible to start a later current initialization attempt. The blocked path SHALL add no dedicated UI, notification, success feedback, close-tabs instruction, or alternate persistence path.
+
+#### Scenario: Blocked deletion reaches a bounded terminal
+
+- **GIVEN** canonical message-database deletion has reported `blocked` and has not settled
+- **WHEN** five seconds elapse
+- **THEN** the current preparation SHALL reject, initialization SHALL remain non-ready, one normalized retryable initialization error SHALL be available, and no competing deletion SHALL start
+
+#### Scenario: Deletion settles before the blocked deadline
+
+- **GIVEN** canonical message-database deletion reported `blocked`
+- **WHEN** that same request succeeds before five seconds elapse
+- **THEN** WebChat SHALL clear the blocked deadline, recreate the canonical database at the configured version, and continue the same current initialization attempt
+
+#### Scenario: Retry owns a new initialization attempt
+
+- **GIVEN** a blocked-deletion deadline terminated the current initialization attempt
+- **WHEN** the user activates actions-menu Refresh
+- **THEN** one new current attempt SHALL re-evaluate persisted storage truth, while the failed attempt SHALL not publish readiness or settle the new attempt

--- a/openspec/changes/prepare-firefox-persistence-without-web-locks/tasks.md
+++ b/openspec/changes/prepare-firefox-persistence-without-web-locks/tasks.md
@@ -1,0 +1,20 @@
+> **Acceptance status (2026-08-01):** The Owner explicitly accepted PR #91 at immutable source exact `5d6aff72c96b11a23272956aee9755db108edc26` through the unified PR #91-#94 acceptance branch. Fresh architecture-first Review task #515 passed with P0/P1/P2 `0/0/0`, and exact CI passed 4/4. Real Firefox production initialization and concurrent-tab behavior passed; the five-second blocked terminal is covered deterministically and remains real-browser `UNVERIFIED`, not PASS. Owner acceptance is conditional Ready/merge authorization after this PM-owned documentation child and final identity/CI gates.
+
+## 1. Product Authority
+
+- [x] 1.1 Define Firefox direct persistence preparation and Chrome Web Locks arbitration at browser composition.
+- [x] 1.2 Preserve one versioned persistence lifecycle, canonical identities, generation fencing, and idempotent current-version writes without alternate state.
+- [x] 1.3 Define the five-second blocked IndexedDB deletion terminal and retryable initialization feedback.
+
+## 2. Source And Regression Coverage
+
+- [x] 2.1 Inject one preparation coordinator into origin-local configuration and canonical message-database preparation.
+- [x] 2.2 Keep Firefox free of Web Locks execution while Chrome owns Web Locks arbitration.
+- [x] 2.3 Cover direct/Web Locks selection, concurrent convergence, abort generations, blocked deadline settlement, and Retry through final-result tests.
+
+## 3. Delivery Gates
+
+- [x] 3.1 Pass focused and complete tests, typecheck, format, lint, Chrome/Firefox production builds, and runtime boundary gates on the immutable source exact; pass strict OpenSpec on this documentation child.
+- [x] 3.2 Obtain fresh architecture-first Review with no remaining P0/P1/P2 finding and exact-bound CI success.
+- [x] 3.3 Record real Firefox initialization and concurrent-tab truth separately from deterministic blocked-timeout coverage without inventing a browser PASS.
+- [x] 3.4 Record explicit Owner acceptance as conditional merge authorization and hand final identity/CI, Ready, and merge execution to Coder after this documentation child.

--- a/src/app/content/index.tsx
+++ b/src/app/content/index.tsx
@@ -25,6 +25,7 @@ import NotificationDomain from '@/domain/Notification'
 import AppFeedbackDomain from '@/domain/AppFeedback'
 import { createElement } from '@/utils'
 import { requestBrowserSyncStoragePreparation } from '@/service/StoragePreparation'
+import { createDirectPreparationCoordinator, createWebLocksPreparationCoordinator } from '@/utils/withPreparationLock'
 import { MessageDatabaseExtern, type MessageDatabaseSchema } from '@/domain/MessageStore'
 import { ChatRoomExtern, type ChatRoom } from '@/domain/externs/ChatRoom'
 import { WorldRoomExtern, type WorldRoom } from '@/domain/externs/WorldRoom'
@@ -32,10 +33,19 @@ import { ReadinessExtern, type Readiness } from '@/domain/externs/Readiness'
 import { BrowserSyncStorageExtern, type Storage, type StorageValue } from '@/domain/externs/Storage'
 import type { Database } from '@/domain/externs/Database'
 
+/**
+ * Firefox content scripts cannot assimilate page-realm Web Locks Promises
+ * (<https://bugzilla.mozilla.org/show_bug.cgi?id=1873028>), so Firefox runs preparation directly and relies
+ * on versioned idempotent writes for cross-tab convergence; Chrome keeps Web Locks arbitration.
+ */
+const preparationLockCoordinator = import.meta.env.FIREFOX
+  ? createDirectPreparationCoordinator()
+  : createWebLocksPreparationCoordinator()
+
 const initializationDependencies: InitializationDependencies = {
   prepareBrowserSyncStorage: requestBrowserSyncStoragePreparation,
-  prepareLocalStorage: prepareLocalConfigurationStorage,
-  prepareMessageDatabase: prepareIndexedDBMessageDatabase,
+  prepareLocalStorage: () => prepareLocalConfigurationStorage(preparationLockCoordinator),
+  prepareMessageDatabase: () => prepareIndexedDBMessageDatabase(preparationLockCoordinator),
   initializeRuntime: initClient,
   detachRuntime: detachClient
 }

--- a/src/domain/ApplicationPorts.test.ts
+++ b/src/domain/ApplicationPorts.test.ts
@@ -197,7 +197,9 @@ describe('replaceable application boundaries', () => {
     expect(storageConstants).toContain("export const APP_STATUS_STORAGE_KEY = 'WEB_CHAT_APP_STATUS'")
     expect(storageConstants).toContain("export const USER_INFO_STORAGE_KEY = 'WEB_CHAT_USER_INFO'")
     expect(indexedDB.match(/createMessageDatabaseDefinition\(STORAGE_NAME, MESSAGE_STORE_VERSION\)/g)).toHaveLength(2)
-    expect(indexedDB).toContain('withPreparationLock(`message:${STORAGE_NAME}`')
+    expect(indexedDB).toMatch(/withPreparationLock\(\s*`message:\$\{STORAGE_NAME\}`/)
+    expect(indexedDB).toContain('MESSAGE_STORE_DELETION_BLOCKED_TIMEOUT_MS')
+    expect(indexedDB).toContain("reject(new Error('Message store deletion blocked'))")
     expect(indexedDB).toContain('database.name === STORAGE_NAME')
     expect(indexedDB).toContain('const deleteMessageDatabase = (): Promise<void> =>')
     expect(indexedDB).toContain('indexedDB.deleteDatabase(STORAGE_NAME)')
@@ -223,8 +225,13 @@ describe('replaceable application boundaries', () => {
     }
 
     expect(content).toContain('prepareBrowserSyncStorage: requestBrowserSyncStoragePreparation')
-    expect(content).toContain('prepareLocalStorage: prepareLocalConfigurationStorage')
-    expect(content).toContain('prepareMessageDatabase: prepareIndexedDBMessageDatabase')
+    expect(content).toContain(
+      'const preparationLockCoordinator = import.meta.env.FIREFOX\n  ? createDirectPreparationCoordinator()\n  : createWebLocksPreparationCoordinator()'
+    )
+    expect(content).toContain('prepareLocalStorage: () => prepareLocalConfigurationStorage(preparationLockCoordinator)')
+    expect(content).toContain(
+      'prepareMessageDatabase: () => prepareIndexedDBMessageDatabase(preparationLockCoordinator)'
+    )
     expect(content).toContain('initializeRuntime: initClient')
     expect(content).toContain('startInitializationLifecycle({')
     expect(content).toContain('dependencies: initializationDependencies')

--- a/src/domain/impls/Storage.test.ts
+++ b/src/domain/impls/Storage.test.ts
@@ -446,4 +446,25 @@ describe('configuration storage version ownership', () => {
     expect(other.values.get('other')).toBe('preserved')
     expect(other.storage.clear).not.toHaveBeenCalled()
   })
+
+  it('arbitrates an injected coordinator lease across the preparation lifecycle', async () => {
+    const fixture = createVersionStorage({ exists: false })
+    const events: string[] = []
+    const coordinator = {
+      acquire: vi.fn(async () => {
+        events.push('acquire')
+        return () => {
+          events.push('release')
+        }
+      })
+    }
+    const identity = `coordinated-${configurationStorageId++}`
+    const { prepareConfigurationStorage } = await import('./Storage')
+
+    await prepareConfigurationStorage(identity, fixture.storage, coordinator)
+
+    expect(coordinator.acquire).toHaveBeenCalledWith(`configuration:${identity}`)
+    expect(events).toEqual(['acquire', 'release'])
+    expect(fixture.version()).toEqual({ exists: true, value: CONFIG_STORE_VERSION })
+  })
 })

--- a/src/domain/impls/Storage.ts
+++ b/src/domain/impls/Storage.ts
@@ -8,7 +8,7 @@ import {
   STORAGE_NAME
 } from '@/constants/storage'
 import webExtensionDriver from '@/utils/webExtensionDriver'
-import { withPreparationLock } from '@/utils/withPreparationLock'
+import { withPreparationLock, type PreparationLockCoordinator } from '@/utils/withPreparationLock'
 import type { Storage } from '@/domain/externs/Storage'
 import { EVENT } from '@/constants/event'
 
@@ -18,27 +18,35 @@ export interface ConfigurationVersionStorage {
   clear(): Promise<void>
 }
 
-export const prepareConfigurationStorage = (identity: string, storage: ConfigurationVersionStorage): Promise<void> =>
-  withPreparationLock(`configuration:${identity}`, async (lock) => {
-    try {
-      const stored = await lock.read(storage.readVersion())
-      if (!stored.exists) {
+export const prepareConfigurationStorage = (
+  identity: string,
+  storage: ConfigurationVersionStorage,
+  coordinator?: PreparationLockCoordinator
+): Promise<void> =>
+  withPreparationLock(
+    `configuration:${identity}`,
+    async (lock) => {
+      try {
+        const stored = await lock.read(storage.readVersion())
+        if (!stored.exists) {
+          await lock.write(() => storage.writeVersion(CONFIG_STORE_VERSION))
+          lock.checkpoint()
+          return
+        }
+        if (stored.value === CONFIG_STORE_VERSION) return
+
+        await lock.write(() => storage.clear())
+        lock.checkpoint()
         await lock.write(() => storage.writeVersion(CONFIG_STORE_VERSION))
         lock.checkpoint()
-        return
+      } catch (error) {
+        if (lock.signal.aborted) throw error
+        console.error('[WebChat] Configuration store preparation failed')
+        throw new Error('Configuration store preparation failed')
       }
-      if (stored.value === CONFIG_STORE_VERSION) return
-
-      await lock.write(() => storage.clear())
-      lock.checkpoint()
-      await lock.write(() => storage.writeVersion(CONFIG_STORE_VERSION))
-      lock.checkpoint()
-    } catch (error) {
-      if (lock.signal.aborted) throw error
-      console.error('[WebChat] Configuration store preparation failed')
-      throw new Error('Configuration store preparation failed')
-    }
-  })
+    },
+    coordinator
+  )
 
 /**
  * Waiting to be resolved
@@ -57,18 +65,22 @@ const clearVersionManagedLocalConfiguration = async () => {
   await Promise.all(keys.filter((key) => key !== APP_STATUS_STORAGE_KEY).map((key) => localStorage.removeItem(key)))
 }
 
-export const prepareLocalConfigurationStorage = (): Promise<void> =>
-  prepareConfigurationStorage(`origin-local:${globalThis.location?.origin ?? 'headless'}`, {
-    async readVersion() {
-      const exists = await localStorage.hasItem(CONFIG_STORE_VERSION_KEY)
-      return {
-        exists,
-        value: exists ? await localStorage.getItem(CONFIG_STORE_VERSION_KEY) : undefined
-      }
+export const prepareLocalConfigurationStorage = (coordinator?: PreparationLockCoordinator): Promise<void> =>
+  prepareConfigurationStorage(
+    `origin-local:${globalThis.location?.origin ?? 'headless'}`,
+    {
+      async readVersion() {
+        const exists = await localStorage.hasItem(CONFIG_STORE_VERSION_KEY)
+        return {
+          exists,
+          value: exists ? await localStorage.getItem(CONFIG_STORE_VERSION_KEY) : undefined
+        }
+      },
+      writeVersion: (version) => localStorage.setItem(CONFIG_STORE_VERSION_KEY, version),
+      clear: clearVersionManagedLocalConfiguration
     },
-    writeVersion: (version) => localStorage.setItem(CONFIG_STORE_VERSION_KEY, version),
-    clear: clearVersionManagedLocalConfiguration
-  })
+    coordinator
+  )
 
 export const LocalStorageImpl = LocalStorageExtern.impl({
   get: localStorage.getItem,

--- a/src/domain/impls/database/IndexedDB.test.ts
+++ b/src/domain/impls/database/IndexedDB.test.ts
@@ -332,6 +332,62 @@ describe('IndexedDB Message database version ownership', () => {
     expect(diagnostics).toContainEqual(['[WebChat] Persistence preparation coordination unavailable'])
   })
 
+  it('fails a blocked deletion visibly after the bounded window instead of hanging', async () => {
+    const name = STORAGE_NAME
+    names.add(name)
+    const blocker = await openDB(name, 1, {
+      upgrade(database) {
+        database.createObjectStore('legacy')
+      }
+    })
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const diagnostic = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const timers: Array<{ callback: () => void; ms?: number }> = []
+    const nativeSetTimeout = globalThis.setTimeout
+    vi.stubGlobal(
+      'setTimeout',
+      vi.fn((callback: () => void, ms?: number, ...args: unknown[]) => {
+        timers.push({ callback, ms })
+        return nativeSetTimeout(callback, ms, ...args)
+      })
+    )
+
+    let settled = false
+    const preparation = prepareIndexedDBMessageDatabase().then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await vi.waitFor(() => expect(warning).toHaveBeenCalledTimes(1))
+    expect(settled).toBe(false)
+
+    // Force the bounded blocked window to expire while the contender still holds the old store open.
+    const blockedTimer = timers.find(({ ms }) => ms === 5000)
+    expect(blockedTimer).toBeDefined()
+    blockedTimer!.callback()
+
+    await expect(preparation).resolves.toBeUndefined()
+    expect(settled).toBe(true)
+    expect(diagnostic).toHaveBeenCalledWith('[WebChat] Message store preparation failed')
+    vi.stubGlobal('setTimeout', nativeSetTimeout)
+
+    blocker.close()
+    const unchanged = await openDB(name)
+    expect(unchanged.version).toBe(1)
+    unchanged.close()
+
+    // The visible failure is retryable: once the contender releases, preparation converges.
+    await prepareIndexedDBMessageDatabase()
+    const rebuilt = await openDB(name)
+    expect(rebuilt.version).toBe(MESSAGE_STORE_VERSION)
+    rebuilt.close()
+    warning.mockRestore()
+    diagnostic.mockRestore()
+  })
+
   it('keeps a blocked delete non-ready and completes the same request after release', async () => {
     const name = STORAGE_NAME
     names.add(name)

--- a/src/domain/impls/database/IndexedDB.ts
+++ b/src/domain/impls/database/IndexedDB.ts
@@ -21,7 +21,7 @@ import {
   type StoreDefinition,
   type ValidatedQuery
 } from './Definition'
-import { withPreparationLock } from '@/utils/withPreparationLock'
+import { withPreparationLock, type PreparationLockCoordinator } from '@/utils/withPreparationLock'
 
 type StoreName<Schema> = keyof Schema & string
 
@@ -543,37 +543,76 @@ export const createIndexedDBDatabase = <Schema extends DatabaseSchema<Schema>>(
   definition: DatabaseDefinition<Schema>
 ): Database<Schema> => new IndexedDBDatabase(definition)
 
+/**
+ * A cross-tab deletion contender can hold the old store open indefinitely (Firefox preparation runs without
+ * cross-tab locking); bound the blocked window so migration fails visibly instead of hanging forever.
+ */
+const MESSAGE_STORE_DELETION_BLOCKED_TIMEOUT_MS = 5000
+
 const deleteMessageDatabase = (): Promise<void> =>
   new Promise((resolve, reject) => {
     const request = indexedDB.deleteDatabase(STORAGE_NAME)
-    request.addEventListener('blocked', () => console.warn('[WebChat] Message store reset is blocked'), { once: true })
-    request.addEventListener('success', () => resolve(), { once: true })
-    request.addEventListener('error', () => reject(new Error('Message store deletion failed')), { once: true })
+    let blockedTimer: ReturnType<typeof globalThis.setTimeout> | null = null
+    const clearBlockedTimer = () => {
+      if (blockedTimer === null) return
+      globalThis.clearTimeout(blockedTimer)
+      blockedTimer = null
+    }
+    request.addEventListener(
+      'blocked',
+      () => {
+        console.warn('[WebChat] Message store reset is blocked')
+        blockedTimer ??= globalThis.setTimeout(() => {
+          reject(new Error('Message store deletion blocked'))
+        }, MESSAGE_STORE_DELETION_BLOCKED_TIMEOUT_MS)
+      },
+      { once: true }
+    )
+    request.addEventListener(
+      'success',
+      () => {
+        clearBlockedTimer()
+        resolve()
+      },
+      { once: true }
+    )
+    request.addEventListener(
+      'error',
+      () => {
+        clearBlockedTimer()
+        reject(new Error('Message store deletion failed'))
+      },
+      { once: true }
+    )
   })
 
-export const prepareIndexedDBMessageDatabase = (): Promise<void> => {
+export const prepareIndexedDBMessageDatabase = (coordinator?: PreparationLockCoordinator): Promise<void> => {
   const definition = createMessageDatabaseDefinition(STORAGE_NAME, MESSAGE_STORE_VERSION)
 
-  return withPreparationLock(`message:${STORAGE_NAME}`, async (lock) => {
-    try {
-      const databases = await lock.read(indexedDB.databases())
-      const existing = databases.find((database) => database.name === STORAGE_NAME)
-      if (existing && existing.version !== MESSAGE_STORE_VERSION) {
-        await lock.write(async () => {
-          await deleteMessageDatabase()
-        })
-        lock.checkpoint()
-      }
+  return withPreparationLock(
+    `message:${STORAGE_NAME}`,
+    async (lock) => {
+      try {
+        const databases = await lock.read(indexedDB.databases())
+        const existing = databases.find((database) => database.name === STORAGE_NAME)
+        if (existing && existing.version !== MESSAGE_STORE_VERSION) {
+          await lock.write(async () => {
+            await deleteMessageDatabase()
+          })
+          lock.checkpoint()
+        }
 
-      const database = await lock.write(() => openDatabase(definition))
-      database.close()
-      lock.checkpoint()
-    } catch (error) {
-      if (lock.signal.aborted) throw error
-      console.error('[WebChat] Message store preparation failed')
-      throw new Error('Message store preparation failed')
-    }
-  })
+        const database = await lock.write(() => openDatabase(definition))
+        database.close()
+        lock.checkpoint()
+      } catch (error) {
+        if (lock.signal.aborted) throw error
+        console.error('[WebChat] Message store preparation failed')
+        throw new Error('Message store preparation failed')
+      }
+    },
+    coordinator
+  )
 }
 
 export const createIndexedDBMessageDatabase = (): Database<MessageDatabaseSchema> =>

--- a/src/utils/withPreparationLock.test.ts
+++ b/src/utils/withPreparationLock.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { installTestWebLocks } from './withPreparationLock.test-utils'
-import { withPreparationLock } from './withPreparationLock'
+import { createDirectPreparationCoordinator, withPreparationLock } from './withPreparationLock'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -29,5 +29,76 @@ describe('persistence preparation lock', () => {
     expect(prepare).not.toHaveBeenCalled()
     expect(diagnostic).toHaveBeenCalledWith('[WebChat] Persistence preparation coordination unavailable')
     diagnostic.mockRestore()
+  })
+})
+
+describe('persistence preparation lock coordinator', () => {
+  it('holds the injected coordinator lease across preparation and releases on settle', async () => {
+    const events: string[] = []
+    const coordinator = {
+      acquire: vi.fn(async () => {
+        events.push('acquire')
+        return () => {
+          events.push('release')
+        }
+      })
+    }
+    const prepare = vi.fn(async () => {
+      events.push('prepare')
+    })
+
+    await withPreparationLock('coordinated', prepare, coordinator)
+
+    expect(coordinator.acquire).toHaveBeenCalledWith('coordinated')
+    expect(events).toEqual(['acquire', 'prepare', 'release'])
+  })
+
+  it('releases the injected lease when preparation rejects', async () => {
+    const release = vi.fn()
+    const coordinator = { acquire: vi.fn(async () => release) }
+    const prepare = vi.fn(async () => {
+      throw new Error('physical failure')
+    })
+
+    await expect(withPreparationLock('coordinated-failure', prepare, coordinator)).rejects.toThrow('physical failure')
+
+    expect(release).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases an injected lease granted after supersede without running stale preparation', async () => {
+    const grants: Array<() => void> = []
+    const releases = [vi.fn(), vi.fn()]
+    const coordinator = {
+      acquire: vi.fn(() => {
+        const index = grants.length
+        return new Promise<() => void>((resolve) => {
+          grants.push(() => resolve(releases[index]))
+        })
+      })
+    }
+    const stale = vi.fn(async () => {})
+    const current = vi.fn(async () => {})
+
+    const first = withPreparationLock('coordinated-supersede', stale, coordinator)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const second = withPreparationLock('coordinated-supersede', current, coordinator)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    // Both generations are granted only after the first was superseded.
+    for (const grant of grants.splice(0)) grant()
+
+    await expect(second).resolves.toBeUndefined()
+    await expect(first).resolves.toBeUndefined()
+    expect(stale).not.toHaveBeenCalled()
+    expect(current).toHaveBeenCalledTimes(1)
+    expect(releases[0]).toHaveBeenCalledTimes(1)
+    expect(releases[1]).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs preparation directly without cross-context arbitration under the direct coordinator', async () => {
+    const prepare = vi.fn(async () => {})
+
+    await withPreparationLock('direct', prepare, createDirectPreparationCoordinator())
+
+    expect(prepare).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/utils/withPreparationLock.ts
+++ b/src/utils/withPreparationLock.ts
@@ -5,6 +5,14 @@ export interface PreparationLock {
   checkpoint(): void
 }
 
+/**
+ * Cross-context mutual exclusion for persistence preparation. Acquiring returns the release callback; the
+ * implementation decides whether arbitration is local (Web Locks) or delegated (background-mediated).
+ */
+export interface PreparationLockCoordinator {
+  acquire(identity: string): Promise<() => void>
+}
+
 interface PreparationCompletion {
   readonly promise: Promise<void>
   readonly resolve: () => void
@@ -58,9 +66,48 @@ const settleGeneration = (identity: string, generation: PreparationGeneration, o
   else generation.completion.reject(outcome.error)
 }
 
+/**
+ * Web Locks arbitration. Firefox content scripts cannot assimilate the page-realm lock Promise
+ * (`Permission denied to access property "then"`), so those contexts delegate arbitration to the
+ * background-mediated coordinator instead.
+ */
+export const createWebLocksPreparationCoordinator = (
+  lockManager?: Pick<LockManager, 'request'>
+): PreparationLockCoordinator => ({
+  acquire: (identity) =>
+    new Promise<() => void>((resolve, reject) => {
+      const locks = lockManager ?? (typeof navigator === 'undefined' ? undefined : navigator.locks)
+      if (!locks) {
+        console.error('[WebChat] Persistence preparation coordination unavailable')
+        reject(new Error('Persistence preparation coordination unavailable'))
+        return
+      }
+      let release!: () => void
+      const gate = new Promise<void>((grantRelease) => {
+        release = grantRelease
+      })
+      void locks
+        .request(`webchat-persistence:${identity}`, () => {
+          resolve(() => release())
+          return gate
+        })
+        .then(undefined, reject)
+    })
+})
+
+/**
+ * No cross-context arbitration: preparation runs directly and relies on versioned idempotent writes for
+ * cross-tab convergence. Used by Firefox content scripts where Web Locks cannot cross the Xray boundary
+ * (<https://bugzilla.mozilla.org/show_bug.cgi?id=1873028>).
+ */
+export const createDirectPreparationCoordinator = (): PreparationLockCoordinator => ({
+  acquire: () => Promise.resolve(() => {})
+})
+
 export const withPreparationLock = (
   identity: string,
-  prepare: (lock: PreparationLock) => Promise<void>
+  prepare: (lock: PreparationLock) => Promise<void>,
+  coordinator: PreparationLockCoordinator = createWebLocksPreparationCoordinator()
 ): Promise<void> => {
   const current = preparations.get(identity)
   const completion = current?.completion ?? createCompletion()
@@ -75,25 +122,23 @@ export const withPreparationLock = (
   const lock: PreparationLock = {
     signal,
     read: (operation) => raceWithSignal(operation, signal),
-    // Once a write starts, retain the physical Web Lock until that write settles.
+    // Once a write starts, retain the physical lock until that write settles.
     write: async (operation) => {
       signal.throwIfAborted()
       return operation()
     },
     checkpoint: () => signal.throwIfAborted()
   }
-  const preparation = Promise.resolve().then(() => {
+  const preparation = Promise.resolve().then(async () => {
     signal.throwIfAborted()
-    const locks = typeof navigator === 'undefined' ? undefined : navigator.locks
-    if (!locks) {
-      console.error('[WebChat] Persistence preparation coordination unavailable')
-      throw new Error('Persistence preparation coordination unavailable')
-    }
-    return locks.request(`webchat-persistence:${identity}`, async () => {
+    const release = await coordinator.acquire(identity)
+    try {
       signal.throwIfAborted()
       await prepare(lock)
       signal.throwIfAborted()
-    })
+    } finally {
+      release()
+    }
   })
   void preparation.then(
     () => settleGeneration(identity, generation, { status: 'resolved' }),


### PR DESCRIPTION
## Why

Firefox 生产版初始化必炸：`Initialization unavailable: Permission denied to access property "then"`。根因（真实 Firefox 生产构建探针证实）：content script 中 `navigator.locks.request` 返回页面 realm 的 Promise，跨 compartment assimilation 被 Firefox 拒绝——Mozilla 官方 bug <https://bugzilla.mozilla.org/show_bug.cgi?id=1873028>（NEW，FF121+，未修复，Rob Wu 根因分析）。`prepareLocalStorage`/`prepareMessageDatabase` 在 content script 内经 `withPreparationLock` 使用 Web Locks，导致初始化在 s2 即失败。

## What changes（Owner 确认的 B 方案 + blocked 超时护栏）

- `withPreparationLock` 引入可注入 `PreparationLockCoordinator`（acquire→release；in-tab generation 去重/abort 语义不变）。
- Firefox content script → `createDirectPreparationCoordinator`：无锁直跑，跨 tab 由版本化幂等写收敛；Chrome 保持 `createWebLocksPreparationCoordinator` 不变。
- IDB 护栏：`deleteDatabase` blocked 超 5s 未解除则以可见失败收尾（error toast + 可 retry），不再永久挂起；解除则正常完成。

## 验证

- 门禁：Vitest 555/555、tsc、format、lint 0 errors、Chrome MV3 + Firefox MV2 构建全 PASS。
- 真实 Firefox 生产构建（web-ext 临时加载）：FAIL-before 探针复现 locks 必拒；候选双 tab example.com 均初始化通过、无 error toast、渲染 Open WebChat。
- blocked 超时路径：确定性单测覆盖（真实浏览器验证需专用版本错配构建，未做）。

任务：task #513；fresh Review：task #515。