### PR TITLE
fix(content): replace initialization loading toast with its error successor

### DIFF
--- a/openspec/changes/keep-retry-error-toast-visible/.openspec.yaml
+++ b/openspec/changes/keep-retry-error-toast-visible/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-08-01
+goal: Replace initialization loading with the matching error atomically so a
+  failed Retry always leaves a visible current error Toast.

--- a/openspec/changes/keep-retry-error-toast-visible/README.md
+++ b/openspec/changes/keep-retry-error-toast-visible/README.md
@@ -1,0 +1,3 @@
+# keep-retry-error-toast-visible
+
+Keep the current initialization error visible when a retried attempt fails.

--- a/openspec/changes/keep-retry-error-toast-visible/design.md
+++ b/openspec/changes/keep-retry-error-toast-visible/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`Initialization.ts` owns one current attempt generation and publishes generic feedback through `ToastDomain`. An attempt starts with the stable `webchat-initialization` loading descriptor. AppStatus remains the sole owner of `connecting | unavailable | ready`, and the actions-menu Refresh starts the next attempt.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make current initialization failure one atomic loading-to-error replacement.
+- Keep the normalized error visible for the generic Toast's default lifetime or until ordinary user dismissal/replacement.
+- Preserve success cancellation and generation fencing.
+
+**Non-Goals:**
+
+- Adding another Toast identity, timer, renderer, presenter, state owner, error component, Retry control, or browser branch.
+- Changing initialization stage order, deadlines, error copy, shell composition, Toast styling, or Runtime/storage behavior.
+- Retaining errors from superseded, aborted, or unmounted attempts.
+
+## Decisions
+
+### 1. The stable descriptor identity represents the current attempt
+
+Initial execution and every Retry publish `Preparing WebChat` with ID `webchat-initialization`. The current terminal result settles that same identity. A successful attempt cancels its matching loading descriptor. A failed attempt publishes `WebChat unavailable` as an error descriptor with the same ID.
+
+### 2. Failure replacement performs no preceding cancel
+
+The failure command batch marks AppStatus unavailable and publishes the same-ID error. It does not cancel that ID first. This makes the error the direct successor of loading and prevents asynchronous dismissal work for the same identity from deleting the newly published terminal.
+
+### 3. Existing generation ownership remains authoritative
+
+Only the active, non-aborted generation may publish success or error. Starting Retry aborts the prior attempt and publishes loading for the new generation. Delayed work from the prior generation cannot cancel, replace, or otherwise settle the current descriptor.
+
+### 4. Generic Toast behavior remains the presentation boundary
+
+The error retains the existing copy, dismissibility, default lifetime, replacement behavior, and panel-owned Toaster. Initialization owns only operation settlement; it adds no timer, DOM observation, Toast acknowledgement, or presentation state.
+
+### 5. Verification exercises the real feedback boundary
+
+Controls cover an initial failure, failure after Retry, repeated current failures, success after Retry, abort/unmount, stale generations, and unrelated Toast identities. Browser-rendered coverage proves the same-ID error remains after the framework's deferred publish cycle.
+
+## Risks / Trade-offs
+
+- [The same ID is reused across attempts] -> Attempt generation fencing decides which operation may settle it.
+- [The Toast library schedules descriptor work asynchronously] -> Failure publishes one successor descriptor and creates no preceding cancel for that ID.
+- [A later Retry replaces the current error with loading] -> That is the new user-requested attempt and retains the same single feedback identity.

--- a/openspec/changes/keep-retry-error-toast-visible/proposal.md
+++ b/openspec/changes/keep-retry-error-toast-visible/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Every current initialization attempt uses one stable Toast identity. When a retried attempt fails, its terminal error must replace that attempt's loading feedback directly and remain visible under the generic Toast lifetime instead of being removed by delayed cleanup for the same identity.
+
+## What Changes
+
+- Keep `webchat-initialization` as the sole initialization Toast identity for initial attempts and Retry.
+- On current failure, replace the matching loading descriptor directly with the normalized `WebChat unavailable` error descriptor.
+- Do not issue a matching cancellation before the failure replacement. Success still cancels the matching loading descriptor.
+- Preserve generation fencing: superseded, aborted, or unmounted attempts publish no terminal error and cannot settle a newer attempt.
+- Preserve the existing shell, AppStatus owner, generic Toaster, default error lifetime, actions-menu Refresh, and all Runtime/storage behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `webrtc-runtime`: Define atomic same-identity loading-to-error settlement for current initialization failure.
+
+## Impact
+
+- Affected behavior: generic Toast feedback after a current initial or retried initialization attempt fails.
+- Affected implementation: the terminal failure command batch in the existing initialization lifecycle.
+- Affected verification: initial failure, Retry failure, success, stale generation, unmount, default lifetime, and unrelated Toast preservation.
+- Unchanged: initialization stages and deadline, shell structure, AppStatus ownership, Retry availability, Toast copy and identity, Runtime, persistence, protocol, public APIs, dependencies, and permissions.

--- a/openspec/changes/keep-retry-error-toast-visible/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/keep-retry-error-toast-visible/specs/webrtc-runtime/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Current initialization failure replaces matching loading with a visible error
+
+Every current initialization attempt SHALL use stable Toast ID `webchat-initialization`. Starting the attempt SHALL publish `Preparing WebChat` loading for that ID. Current success SHALL cancel the matching loading descriptor. Current failure SHALL mark initialization unavailable and publish the normalized `WebChat unavailable` error descriptor with the same ID as a direct replacement; it SHALL NOT issue a cancel for that ID before publishing the error.
+
+The error SHALL remain governed by the generic Toast's existing default lifetime, user dismissal, and later descriptor replacement. Ordinary failure settlement SHALL NOT immediately remove it. Superseded, aborted, unmounted, or stale generations SHALL publish no terminal error and SHALL NOT cancel or replace feedback owned by a newer attempt. This requirement SHALL add no second Toast identity, presenter, renderer, timer, status component, Retry control, or operation state owner.
+
+#### Scenario: Initial failure replaces loading
+
+- **GIVEN** the current initial attempt owns `webchat-initialization` loading
+- **WHEN** that attempt fails while it remains active
+- **THEN** one same-ID `WebChat unavailable` error SHALL directly replace loading, no preceding same-ID cancel SHALL occur, and the error SHALL remain under ordinary generic Toast lifetime rules
+
+#### Scenario: Retry failure leaves the new error visible
+
+- **GIVEN** the user has started a current Retry and its same-ID loading descriptor is active
+- **WHEN** that retried attempt fails
+- **THEN** the current loading descriptor SHALL become the same-ID error and deferred feedback work from the prior state SHALL NOT remove the new error
+
+#### Scenario: Retry success cancels only matching loading
+
+- **GIVEN** the user has started a current Retry and its same-ID loading descriptor is active
+- **WHEN** that attempt reaches ready
+- **THEN** WebChat SHALL mark initialization ready and cancel the matching loading descriptor without publishing a success Toast
+
+#### Scenario: Stale attempt cannot settle current feedback
+
+- **GIVEN** a newer initialization generation owns the stable Toast identity
+- **WHEN** an older superseded, aborted, or unmounted generation later resolves or rejects
+- **THEN** the older generation SHALL publish no ready state, unavailable state, cancel, or error descriptor for the current attempt
+
+#### Scenario: Unrelated Toasts remain independent
+
+- **GIVEN** another business source owns a different Toast identity
+- **WHEN** initialization succeeds, fails, or starts Retry
+- **THEN** initialization SHALL address only `webchat-initialization` and SHALL NOT dismiss or replace the unrelated Toast

--- a/openspec/changes/keep-retry-error-toast-visible/tasks.md
+++ b/openspec/changes/keep-retry-error-toast-visible/tasks.md
@@ -1,0 +1,20 @@
+> **Acceptance status (2026-08-01):** The Owner explicitly accepted PR #92 at immutable source exact `da489d7f0848e62411abf798863ec6564db8df35` through the unified PR #91-#94 acceptance branch. Fresh Review task #520 passed with no remaining P0/P1/P2 finding, and exact CI passed 4/4. Real Firefox production evidence confirmed that a failed Retry leaves the new error Toast visible. Owner acceptance is conditional Ready/merge authorization after this PM-owned documentation child and final identity/CI gates.
+
+## 1. Product Authority
+
+- [x] 1.1 Keep one stable initialization Toast identity for initial execution and Retry.
+- [x] 1.2 Define current failure as direct same-ID loading-to-error replacement with no preceding cancel.
+- [x] 1.3 Preserve default error lifetime, success cancellation, stale-generation fencing, and unrelated Toast independence.
+
+## 2. Source And Regression Coverage
+
+- [x] 2.1 Set unavailable state and publish the same-ID normalized error in one current failure settlement.
+- [x] 2.2 Keep success, abort, unmount, and supersession behavior unchanged.
+- [x] 2.3 Cover initial failure, Retry failure, success, repeated failure, deferred feedback publication, and stale generations through final-result tests.
+
+## 3. Delivery Gates
+
+- [x] 3.1 Pass focused and complete tests, typecheck, format, lint, and Chrome/Firefox production builds on the immutable source exact; pass strict OpenSpec on this documentation child.
+- [x] 3.2 Obtain fresh architecture-first Review with no remaining P0/P1/P2 finding and exact-bound CI success.
+- [x] 3.3 Record real Firefox Retry failure behavior without inventing an unperformed result.
+- [x] 3.4 Record explicit Owner acceptance as conditional merge authorization and hand final identity/CI, Ready, and merge execution to Coder after this documentation child.

--- a/src/app/content/Initialization.browser.test.tsx
+++ b/src/app/content/Initialization.browser.test.tsx
@@ -1,0 +1,105 @@
+import { render } from 'vitest-browser-react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Remesh } from 'remesh'
+import { Toaster } from 'sonner'
+import { startInitializationLifecycle, type InitializationDependencies } from '@/app/content/Initialization'
+import AppStatusDomain from '@/domain/AppStatus'
+import { ChatRoomExtern } from '@/domain/externs/ChatRoom'
+import { WorldRoomExtern } from '@/domain/externs/WorldRoom'
+import { ReadinessExtern } from '@/domain/externs/Readiness'
+import { BrowserSyncStorageExtern, LocalStorageExtern } from '@/domain/externs/Storage'
+import { ToastImpl } from '@/domain/impls/Toast'
+import { MessageDatabaseExtern } from '@/domain/MessageStore'
+import { createMemoryMessageDatabase } from '@/domain/impls/database/Memory'
+
+let fixtureId = 0
+
+const createFixture = () => {
+  const storage = {
+    get: async () => null,
+    set: async () => {},
+    watch: async () => async () => {}
+  }
+  const chat = {
+    joinRoom: async () => {},
+    leaveRoom: async () => {},
+    sendMessage: async () => {
+      throw new Error('unused')
+    },
+    onMessage: () => () => {},
+    onJoinRoom: () => () => {},
+    onLeaveRoom: () => () => {},
+    onSessions: () => () => {},
+    onError: () => () => {}
+  }
+  const world = {
+    getState: async () => [],
+    onState: () => () => {},
+    onError: () => () => {}
+  }
+  const store = Remesh.store({
+    externs: [
+      ToastImpl,
+      LocalStorageExtern.impl(storage),
+      BrowserSyncStorageExtern.impl(storage),
+      MessageDatabaseExtern.impl(createMemoryMessageDatabase(`initialization-browser-${fixtureId++}`)),
+      ChatRoomExtern.impl(chat),
+      WorldRoomExtern.impl(world),
+      ReadinessExtern.impl({ onState: () => () => {} })
+    ]
+  })
+  const domain = store.getDomain(AppStatusDomain())
+  return { store, domain }
+}
+
+const settle = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const errorToast = () => {
+  const toasts = [...document.querySelectorAll<HTMLElement>('[data-sonner-toast]')].filter((toast) =>
+    toast.textContent?.includes('WebChat unavailable')
+  )
+  return toasts.length > 0 ? toasts : null
+}
+
+describe('initialization error toast ownership (real Sonner boundary)', () => {
+  afterEach(() => {
+    document.querySelector('[data-sonner-toaster]')?.remove()
+  })
+
+  it('keeps the failure error toast presented and replaces it with a new one after a failed retry', async () => {
+    const failing: InitializationDependencies = {
+      prepareBrowserSyncStorage: vi.fn(async () => {}),
+      prepareLocalStorage: vi.fn(async () => {
+        throw new Error('Permission denied to access property "then"')
+      }),
+      prepareMessageDatabase: vi.fn(async () => {}),
+      initializeRuntime: vi.fn(async () => ({})),
+      detachRuntime: vi.fn()
+    }
+    const fixture = createFixture()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await render(<Toaster />)
+    const stop = startInitializationLifecycle({
+      store: fixture.store,
+      dependencies: failing,
+      activateApplicationDependencies: vi.fn()
+    })
+
+    // Initial failure: the error descriptor must stay presented beyond the settlement frame.
+    await vi.waitFor(() => expect(errorToast(), 'initial failure error toast').toBeTruthy())
+    await settle(1000)
+    expect(errorToast(), 'initial error toast must not be actively dismissed by its own settlement').toBeTruthy()
+
+    // Failed retry: the new attempt's failure must present a fresh error toast that also stays.
+    // (The intermediate loading descriptor flashes for only one microtask chain, so assert the retry
+    // through the attempt count instead of racing its presentation.)
+    fixture.store.send(fixture.domain.command.RetryCommand())
+    await vi.waitFor(() => expect(failing.prepareLocalStorage).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(errorToast(), 'retry failure error toast').toBeTruthy())
+    await settle(1000)
+    expect(errorToast(), 'retry error toast must remain presented after the failed attempt').toBeTruthy()
+
+    stop()
+  })
+})

--- a/src/app/content/Initialization.browser.test.tsx
+++ b/src/app/content/Initialization.browser.test.tsx
@@ -1,7 +1,7 @@
 import { render } from 'vitest-browser-react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { Remesh } from 'remesh'
-import { Toaster } from 'sonner'
+import { Toaster, toast } from 'sonner'
 import { startInitializationLifecycle, type InitializationDependencies } from '@/app/content/Initialization'
 import AppStatusDomain from '@/domain/AppStatus'
 import { ChatRoomExtern } from '@/domain/externs/ChatRoom'
@@ -62,10 +62,6 @@ const errorToast = () => {
 }
 
 describe('initialization error toast ownership (real Sonner boundary)', () => {
-  afterEach(() => {
-    document.querySelector('[data-sonner-toaster]')?.remove()
-  })
-
   it('keeps the failure error toast presented and replaces it with a new one after a failed retry', async () => {
     const failing: InitializationDependencies = {
       prepareBrowserSyncStorage: vi.fn(async () => {}),
@@ -101,5 +97,7 @@ describe('initialization error toast ownership (real Sonner boundary)', () => {
     expect(errorToast(), 'retry error toast must remain presented after the failed attempt').toBeTruthy()
 
     stop()
+    // Let the mounted Toaster dismiss the terminal toast through its own lifecycle before React unmounts.
+    toast.dismiss()
   })
 })

--- a/src/app/content/Initialization.test.ts
+++ b/src/app/content/Initialization.test.ts
@@ -133,7 +133,8 @@ describe('initialization lifecycle ownership', () => {
       id: INITIALIZATION_TOAST_ID,
       dismissible: false
     })
-    expect(fixture.toast.cancel).toHaveBeenCalledWith(INITIALIZATION_TOAST_ID)
+    // The same-ID error descriptor directly replaces the loading descriptor; no cancel may race it away.
+    expect(fixture.toast.cancel).not.toHaveBeenCalled()
     expect(fixture.toast.error).toHaveBeenCalledWith('WebChat unavailable', { id: INITIALIZATION_TOAST_ID })
     expect(fixture.activateApplicationDependencies).not.toHaveBeenCalled()
     stop()

--- a/src/app/content/Initialization.ts
+++ b/src/app/content/Initialization.ts
@@ -121,9 +121,11 @@ export const startInitializationLifecycle = ({
         if (!active || signal.aborted || generation !== attemptGeneration) return
         detachRuntime()
         console.error('[WebChat] Initialization unavailable:', error)
+        // No cancel first: sonner defers a same-ID dismiss publish to the next animation frame, which
+        // would land after the error create and immediately remove the fresh error toast. The same-ID
+        // error descriptor directly replaces the loading descriptor (successor replacement).
         store.send([
           appStatus.command.MarkUnavailableCommand(),
-          toast.command.CancelCommand(INITIALIZATION_TOAST_ID),
           toast.command.ErrorCommand({ id: INITIALIZATION_TOAST_ID, message: 'WebChat unavailable' })
         ])
       })


### PR DESCRIPTION
## Why

Firefox 初始化失败后，点击 Retry 再次失败时新的 error toast 被立即关闭（用户感知 toast 一闪而过），不符合 PR #87 错误态可见+可重试合同（task #514，PM 裁决：retry 时 dismiss 旧 toast 合理，但新 attempt 再失败必须弹出新 error toast 并持续可见）。

根因：失败结算在同一同步 batch 内 CancelCommand(id) + ErrorCommand(同 id)。sonner 2.0.7 的 dismiss 把 dismiss 发布延迟到 requestAnimationFrame，落在同步 error create 的 React 更新之后，新 error toast 下一帧被标 delete: true 立即移除。

## What changes

失败结算不再先发 Cancel，同 id error descriptor 直接替换 loading descriptor（successor replacement，合同允许）；成功路径的 Cancel 语义不变。生产变更仅 1 处。

## 验证

- FAIL-before 先行：新增真实边界浏览器测试（真 sonner Toaster + 真 Remesh store + 真 startInitializationLifecycle，vitest Chromium 项目）在父代源码确定性 FAIL x3（error toast 结算后 ~1s 内消失），修复后 PASS。
- 真实 Firefox 生产构建：面板内右键菜单 Retry -> loading -> error toast 持续可见（~4s 10/10 轮询）；再次 Retry 同样弹出新 error toast。
- 门禁：Vitest 550/550（含新浏览器测试）、tsc、format、lint 0 errors、Chrome MV3 + Firefox MV2 构建全 PASS。

任务：task #514；fresh Review：task #518。