### PR TITLE
fix(runtime): preserve error messages across extension transport

### DIFF
--- a/openspec/changes/preserve-runtime-error-message/.openspec.yaml
+++ b/openspec/changes/preserve-runtime-error-message/.openspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-08-01
+goal: Preserve Runtime failure messages across the extension transport boundary
+  while keeping Error construction in the content ChatRoom.

--- a/openspec/changes/preserve-runtime-error-message/README.md
+++ b/openspec/changes/preserve-runtime-error-message/README.md
@@ -1,0 +1,3 @@
+# preserve-runtime-error-message
+
+Carry the Runtime failure message across extension transport and reconstruct the content-side Error.

--- a/openspec/changes/preserve-runtime-error-message/design.md
+++ b/openspec/changes/preserve-runtime-error-message/design.md
@@ -1,0 +1,46 @@
+## Context
+
+The Runtime connection Domain emits an `Error` in the host context. `PagePort` targets that failure to registered pages through the internal Runtime server callback. The callback crosses the browser-extension transport boundary before the Runtime-backed content `ChatRoom` publishes its public `Error` event.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Carry the exact failure message as one transport-safe scalar.
+- Keep transport projection in the host `PagePort` and application `Error` construction in the content `ChatRoom`.
+- Preserve one Runtime failure owner and the ChatRoom error API consumed by application feedback.
+- Verify the real projection and reconstruction path without a test-side copy of production logic.
+
+**Non-Goals:**
+
+- Transporting an `Error` object, name, stack, cause, subclass, or custom metadata.
+- Adding an error DTO, schema, wrapper, codec, status owner, retry state, or browser branch.
+- Changing Runtime recovery, failure targeting, Toast copy, Toast lifetime, or public ChatRoom behavior.
+
+## Decisions
+
+### 1. PagePort owns transport projection
+
+`PagePort.emitError(pageIds, error)` projects the host `Error` to `error.message` before invoking registered page listeners. Its internal listener map and the Runtime server `onError` callback therefore carry `string`. The primitive value is stable under the browser transport's JSON serialization.
+
+This projection stays at `PagePort` because that class already owns page targeting and the host-to-page callback boundary. The connection Domain continues to own the original `Error`; no second failure state is introduced.
+
+### 2. The content ChatRoom owns Error reconstruction
+
+The Runtime-backed content `ChatRoom` receives the message string, constructs `new Error(message)`, and publishes it through its ChatRoom error event. Application consumers continue to receive an `Error` from the same public boundary.
+
+The transport contract remains a string and does not depend on `Error` serialization. Content reconstruction occurs exactly once, at the adapter that owns the application-facing type.
+
+### 3. Message is the complete transport contract
+
+Only `error.message` crosses this boundary. Name, stack, cause, subclasses, enumerable custom fields, and the host object identity are not transported. Toast wording and diagnostics consume the reconstructed Error through their established application path; the transport adds no presentation or normalization policy.
+
+### 4. Verification follows the production ownership path
+
+PagePort coverage serializes the delivered callback value through JSON and requires the exact string. Runtime-backed ChatRoom coverage feeds the string through `RuntimeServer.onError` and requires one reconstructed `Error` with the same message. Higher-level Runtime controls observe `adapter.onError` so tests do not construct a second Error or maintain another message truth.
+
+## Risks / Trade-offs
+
+- [Host-only Error metadata is unavailable in content] -> The message is the deliberate complete transport contract; diagnostics that require other metadata remain in the host context.
+- [A future consumer treats the callback as an Error object] -> The internal Runtime server type fixes the callback to `string`, while the content ChatRoom fixes its public event to `Error`.
+- [Tests could pass by duplicating reconstruction] -> Final controls observe the Runtime-backed ChatRoom adapter rather than rebuilding the Error in fixtures.

--- a/openspec/changes/preserve-runtime-error-message/proposal.md
+++ b/openspec/changes/preserve-runtime-error-message/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Runtime failures cross a browser-extension transport boundary before reaching the content ChatRoom. JavaScript `Error` fields are not reliable transport values, so the boundary must carry the user-relevant message explicitly and reconstruct the content-side `Error` at its owning application adapter.
+
+## What Changes
+
+- Project each host Runtime `Error` to its exact `message` string in `PagePort` before extension transport.
+- Define the transported Runtime error callback as a message string.
+- Reconstruct `new Error(message)` in the content Runtime-backed `ChatRoom` before publishing the ChatRoom error event.
+- Transport no `Error` object, name, stack, cause, or additional error metadata.
+- Preserve the ChatRoom error API, Toast copy and presentation, Runtime failure ownership, page targeting, and listener-failure isolation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `webrtc-runtime`: Define the transport-safe Runtime error message boundary and content-side Error reconstruction.
+
+## Impact
+
+- Affected behavior: Runtime failure feedback delivered from the shared host to a content page.
+- Affected implementation: `PagePort`, the internal Runtime server callback contract, and the Runtime-backed content `ChatRoom` adapter.
+- Affected verification: exact message projection, JSON-safe transport, content Error reconstruction, and final consumer observation.
+- Outside this change: Runtime lifecycle and recovery, Toast wording and lifetime, persistence, protocol, notifications, public ChatRoom APIs, dependencies, permissions, and browser-specific behavior.

--- a/openspec/changes/preserve-runtime-error-message/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/preserve-runtime-error-message/specs/webrtc-runtime/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Runtime errors cross extension transport as message strings
+
+When the shared Runtime host delivers an `Error` to a registered content page, `PagePort` SHALL project that Error to its exact `message` string before invoking the page callback. The internal Runtime server error callback SHALL transport that string and SHALL NOT transport an `Error` object, name, stack, cause, subclass, custom field, or host object identity.
+
+The Runtime-backed content `ChatRoom` SHALL construct `new Error(message)` exactly once and publish that Error through the ChatRoom error event. ChatRoom consumers SHALL continue to receive an `Error` with the exact transported message. This boundary SHALL NOT change Runtime failure ownership, page targeting, listener-failure isolation, recovery behavior, Toast copy, Toast lifetime, or the public ChatRoom API.
+
+#### Scenario: PagePort sends an exact transport-safe message
+
+- **GIVEN** the Runtime host targets `new Error('Runtime transport disconnected')` to a registered page
+- **WHEN** `PagePort` invokes that page's Runtime error callback
+- **THEN** the callback SHALL receive the string `Runtime transport disconnected`, and JSON serialization SHALL preserve that exact value
+
+#### Scenario: Content ChatRoom reconstructs the application Error
+
+- **GIVEN** the content Runtime server callback delivers `Runtime transport disconnected`
+- **WHEN** the current Runtime-backed `ChatRoom` handles that callback
+- **THEN** its ChatRoom error listener SHALL receive one `Error` whose message is exactly `Runtime transport disconnected`
+
+#### Scenario: Host Error metadata does not cross the boundary
+
+- **GIVEN** a host Runtime Error has a name, stack, cause, subclass, or custom field in addition to its message
+- **WHEN** the error is delivered to a content page
+- **THEN** only the message string SHALL cross the extension transport, and content SHALL construct a plain Error from that string
+
+#### Scenario: Final consumer observation uses the reconstructed Error
+
+- **GIVEN** a higher-level application flow observes Runtime-backed ChatRoom errors
+- **WHEN** a Runtime failure reaches that flow
+- **THEN** the observer SHALL receive the Error created by the content ChatRoom and SHALL NOT reconstruct another transport Error in an intermediate consumer

--- a/openspec/changes/preserve-runtime-error-message/tasks.md
+++ b/openspec/changes/preserve-runtime-error-message/tasks.md
@@ -1,0 +1,19 @@
+> **Acceptance status (2026-08-01):** The Owner explicitly accepted PR #93 at immutable source exact `ff8437a551d00358e707473435d00a0cd212727b` through the unified PR #91-#94 acceptance branch. Fresh architecture-first Review task #529 passed with P0/P1/P2 `0/0/0`, and exact CI passed 4/4. Owner acceptance is conditional Ready/merge authorization after this PM-owned documentation child and final identity/CI gates.
+
+## 1. Product Authority
+
+- [x] 1.1 Define `error.message` as the complete host-to-content Runtime error transport value.
+- [x] 1.2 Define content Runtime-backed `ChatRoom` as the sole Error reconstruction boundary.
+- [x] 1.3 Preserve Runtime failure ownership, page targeting, ChatRoom public error behavior, and Toast presentation without transporting Error metadata.
+
+## 2. Source And Regression Coverage
+
+- [x] 2.1 Project host Runtime Errors to their exact message string in `PagePort` before page delivery.
+- [x] 2.2 Type the internal Runtime server error callback as `string` and reconstruct `new Error(message)` in content `ChatRoom`.
+- [x] 2.3 Cover JSON-safe exact-message delivery, content Error reconstruction, and final adapter observation without test-side reconstruction.
+
+## 3. Delivery Gates
+
+- [x] 3.1 Pass focused and complete source tests, typecheck, format, lint, Chrome/Firefox production builds, runtime boundary, and exact CI 4/4 on the immutable source exact; pass strict OpenSpec on this documentation child.
+- [x] 3.2 Obtain fresh architecture-first Review task #529 with P0/P1/P2 `0/0/0` and exact branch/PR identity.
+- [x] 3.3 Record explicit Owner acceptance as conditional merge authorization and hand final identity/CI, Ready, and merge execution to Coder after this documentation child.

--- a/src/domain/impls/runtime/ChatRoom.test.ts
+++ b/src/domain/impls/runtime/ChatRoom.test.ts
@@ -111,6 +111,7 @@ interface ServerFixture {
   server: RuntimeServer
   emitInbound: (event: InboundEvent) => Promise<void>
   emitSession: (event: RuntimeSessionEvent) => Promise<void>
+  emitError: (message: string) => Promise<void>
   emitHistory: (event: HistorySupplyEvent) => void
   resolvedHistory: { supplyId: string; ids: string[]; done: boolean }[]
   sent: ChatMessage[]
@@ -121,6 +122,7 @@ interface ServerFixture {
 const serverFixture = (): ServerFixture => {
   let inbound: ((event: InboundEvent) => void | Promise<void>) | undefined
   let session: ((event: RuntimeSessionEvent) => void | Promise<void>) | undefined
+  let runtimeError: ((message: string) => void | Promise<void>) | undefined
   let history: ((event: HistorySupplyEvent) => void) | undefined
   let leaves = 0
   let reconnects = 0
@@ -180,7 +182,9 @@ const serverFixture = (): ServerFixture => {
       session = listener
     },
     onWorldPresence: async () => {},
-    onError: async () => {},
+    onError: async (_payload, listener) => {
+      runtimeError = listener
+    },
     provideHistory: async (_payload, listener) => {
       history = listener
     },
@@ -196,6 +200,9 @@ const serverFixture = (): ServerFixture => {
     },
     emitSession: async (event) => {
       await session?.(event)
+    },
+    emitError: async (message) => {
+      await runtimeError?.(message)
     },
     emitHistory: (event) => history?.(event),
     resolvedHistory,
@@ -283,6 +290,17 @@ beforeEach(() => vi.useFakeTimers())
 afterEach(() => vi.useRealTimers())
 
 describe('Runtime-backed ChatRoom application port', () => {
+  it('reconstructs a transport-safe Runtime error message for domain listeners', async () => {
+    const { room, emitError } = await setup()
+    const errors: Error[] = []
+    room.onError((error) => errors.push(error))
+    await settle()
+
+    await emitError('Runtime transport disconnected')
+
+    expect(errors).toEqual([new Error('Runtime transport disconnected')])
+  })
+
   it('publishes initialization as one session snapshot without a synthetic join fact', async () => {
     const { room } = await setup()
     const snapshots: Array<readonly ChatSession[]> = []

--- a/src/domain/impls/runtime/ChatRoom.ts
+++ b/src/domain/impls/runtime/ChatRoom.ts
@@ -519,8 +519,8 @@ export class ChatRoom extends EventHub implements ChatRoomPort {
         if (isCurrent() && event.domain === dependencies.pageDomain) this.emitSessionEvent(event)
       })
     attachment.registrations.error = () =>
-      dependencies.server.onError({ pageId: dependencies.pageId }, (error) => {
-        if (isCurrent()) this.emit('error', error)
+      dependencies.server.onError({ pageId: dependencies.pageId }, (message) => {
+        if (isCurrent()) this.emit('error', new Error(message))
       })
     attachment.registrations.history = () =>
       dependencies.server.provideHistory(

--- a/src/runtime/Contract.ts
+++ b/src/runtime/Contract.ts
@@ -144,7 +144,7 @@ export interface RuntimeServer {
     callback: (event: RuntimeSessionEvent) => void | Promise<void>
   ) => Promise<void>
   onWorldPresence: (payload: { pageId: string }, callback: (event: WorldPresenceEvent) => void) => Promise<void>
-  onError: (payload: { pageId: string }, callback: (error: Error) => void) => Promise<void>
+  onError: (payload: { pageId: string }, callback: (message: string) => void) => Promise<void>
   provideHistory: (
     payload: { domain: string; pageId: string },
     callback: (event: HistorySupplyEvent) => void

--- a/src/runtime/JoinNotice.test.ts
+++ b/src/runtime/JoinNotice.test.ts
@@ -335,9 +335,9 @@ const createStack = async (
         await listener(event)
       }),
     onError: (payload, listener) =>
-      server.onError(payload, async (error) => {
-        errors.push(error)
-        await listener(error)
+      server.onError(payload, async (message) => {
+        errors.push(new Error(message))
+        await listener(message)
       })
   }
   let snapshot: RuntimeSnapshot = initialSnapshot

--- a/src/runtime/JoinNotice.test.ts
+++ b/src/runtime/JoinNotice.test.ts
@@ -285,7 +285,7 @@ interface ApplicationStack {
   adapter: RuntimeChatRoom
   store: ReturnType<typeof Remesh.store>
   sessionEvents: RuntimeSessionEvent[]
-  errors: Error[]
+  errors: string[]
   join(): Promise<void>
   rejoin(): Promise<void>
   reload(): void
@@ -326,18 +326,13 @@ const createStack = async (
   const database = createMemoryMessageDatabase(`join-notice-${databaseId++}`)
   const messageStore = createMessageStore(database)
   const sessionEvents: RuntimeSessionEvent[] = []
-  const errors: Error[] = []
+  const errors: string[] = []
   const observedServer: RuntimeServer = {
     ...server,
     onSessionEvent: (payload, listener) =>
       server.onSessionEvent(payload, async (event) => {
         sessionEvents.push(event)
         await listener(event)
-      }),
-    onError: (payload, listener) =>
-      server.onError(payload, async (message) => {
-        errors.push(new Error(message))
-        await listener(message)
       })
   }
   let snapshot: RuntimeSnapshot = initialSnapshot
@@ -352,6 +347,7 @@ const createStack = async (
       return () => {}
     }
   })
+  adapter.onError((error) => errors.push(error.message))
   const storage: Storage = {
     get: async <Value extends StorageValue>() => userInfo(user) as Value,
     set: async () => {},
@@ -704,7 +700,7 @@ describe('application reconnect and durable retirement controls', () => {
     expect(activeLease).toMatchObject({ userId: 'retirement-user-b', status: 'active' })
 
     await b.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() => expect(b.errors.map((error) => error.message)).toContain('retirement write rejected'))
+    await vi.waitFor(() => expect(b.errors).toContain('retirement write rejected'))
 
     const failedSnapshot = await b.server.getSnapshot()
     expect((await durable.load(DOMAIN))?.local).toEqual(activeLease)
@@ -830,7 +826,7 @@ describe('application reconnect and durable retirement controls', () => {
     network.rejectNextSessionEnd('end-peer-b')
 
     await b.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() => expect(b.errors.map((error) => error.message)).toContain('session end send rejected'))
+    await vi.waitFor(() => expect(b.errors).toContain('session end send rejected'))
 
     const chatRoomId = getChatRoomId(DOMAIN)
     const pendingEnd = await durable.load(DOMAIN)
@@ -887,7 +883,7 @@ describe('application reconnect and durable retirement controls', () => {
     network.rejectNextSessionEnd('pending-end-original')
 
     await original.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() => expect(original.errors.map((error) => error.message)).toContain('session end send rejected'))
+    await vi.waitFor(() => expect(original.errors).toContain('session end send rejected'))
     expect((await sharedPresence.load(DOMAIN))?.pendingEnd).toMatchObject({
       presenceId: originalSession.presenceId,
       userId: 'pending-end-user'
@@ -1028,7 +1024,7 @@ describe('application reconnect and durable retirement controls', () => {
     }
     network.rejectNextSessionEnd('retry-inflight-original')
     await original.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() => expect(original.errors.map((error) => error.message)).toContain('session end send rejected'))
+    await vi.waitFor(() => expect(original.errors).toContain('session end send rejected'))
     expect((await sharedPresence.load(DOMAIN))?.pendingEnd?.presenceId).toBe(originalSession.presenceId)
 
     const held = network.holdNextSessionEnd('retry-inflight-original')
@@ -1104,17 +1100,13 @@ describe('application reconnect and durable retirement controls', () => {
     network.rejectNextSessionEnd('retry-transition-releasing')
 
     await releasing.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() =>
-      expect(releasing.errors.map((error) => error.message)).toContain('session end send rejected')
-    )
+    await vi.waitFor(() => expect(releasing.errors).toContain('session end send rejected'))
     const pending = await durable.load(DOMAIN)
     expect(pending?.pendingEnd).toMatchObject({ userId: 'retry-transition-user' })
     rejectRetryTransition = true
 
     await releasing.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() =>
-      expect(releasing.errors.map((error) => error.message)).toContain('retry transition rejected')
-    )
+    await vi.waitFor(() => expect(releasing.errors).toContain('retry transition rejected'))
     expect(await durable.load(DOMAIN)).toEqual(pending)
     expect(network.isJoined('retry-transition-releasing', getChatRoomId(DOMAIN))).toBe(true)
     expect(network.isJoined('retry-transition-releasing', getWorldRoomId())).toBe(true)
@@ -1173,9 +1165,7 @@ describe('application reconnect and durable retirement controls', () => {
     })
 
     await releasing.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() =>
-      expect(releasing.errors.map((error) => error.message)).toContain('final end cleanup rejected')
-    )
+    await vi.waitFor(() => expect(releasing.errors).toContain('final end cleanup rejected'))
     await vi.waitFor(async () =>
       expect((await noticeUsers(observer, NOTICE_TYPE.LEAVE)).filter((id) => id === 'cleanup-user')).toHaveLength(1)
     )
@@ -1234,7 +1224,7 @@ describe('application reconnect and durable retirement controls', () => {
     const originalSession = network.lastSession('settlement-crash-original') as { presenceId: string }
 
     await original.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() => expect(original.errors.map((error) => error.message)).toContain('settled marker rejected'))
+    await vi.waitFor(() => expect(original.errors).toContain('settled marker rejected'))
     await vi.waitFor(async () =>
       expect(
         (await noticeUsers(observer, NOTICE_TYPE.LEAVE)).filter((id) => id === 'settlement-crash-user')
@@ -1310,9 +1300,7 @@ describe('application reconnect and durable retirement controls', () => {
     const originalSession = network.lastSession('cleanup-crash-original') as { presenceId: string }
 
     await original.server.leaveChatRoom({ domain: DOMAIN })
-    await vi.waitFor(() =>
-      expect(original.errors.map((error) => error.message)).toContain('final end cleanup rejected')
-    )
+    await vi.waitFor(() => expect(original.errors).toContain('final end cleanup rejected'))
     await vi.waitFor(async () =>
       expect((await noticeUsers(observer, NOTICE_TYPE.LEAVE)).filter((id) => id === 'cleanup-crash-user')).toHaveLength(
         1

--- a/src/runtime/PagePort.test.ts
+++ b/src/runtime/PagePort.test.ts
@@ -53,6 +53,19 @@ describe('PagePort session-event lifecycle', () => {
   })
 })
 
+describe('PagePort Runtime error delivery', () => {
+  it('keeps the error message intact across the Chrome JSON transport boundary', async () => {
+    const port = new PagePort()
+    const received: unknown[] = []
+    port.onError('page-a', (error) => {
+      received.push(JSON.parse(JSON.stringify(error)))
+    })
+
+    expect(await port.emitError(['page-a'], new Error('Runtime transport disconnected'))).toEqual([])
+    expect(received).toEqual(['Runtime transport disconnected'])
+  })
+})
+
 describe('PagePort history request/response', () => {
   it('settles one supply id exactly once through the explicit response RPC', async () => {
     const port = new PagePort()

--- a/src/runtime/PagePort.ts
+++ b/src/runtime/PagePort.ts
@@ -13,7 +13,7 @@ export class PagePort implements PagePortContract {
   private readonly inbound = new Map<string, (event: InboundEvent) => void | Promise<void>>()
   private readonly sessionEvents = new Map<string, (event: RuntimeSessionEvent) => void | Promise<void>>()
   private readonly worldPresences = new Map<string, (event: WorldPresenceEvent) => void | Promise<void>>()
-  private readonly runtimeErrors = new Map<string, (error: Error) => void | Promise<void>>()
+  private readonly runtimeErrors = new Map<string, (message: string) => void | Promise<void>>()
   private readonly historyProviders = new Map<
     string,
     { domain: string; callback: (event: HistorySupplyEvent) => void }
@@ -42,7 +42,7 @@ export class PagePort implements PagePortContract {
     this.worldPresences.set(pageId, callback)
   }
 
-  onError(pageId: string, callback: (error: Error) => void | Promise<void>) {
+  onError(pageId: string, callback: (message: string) => void | Promise<void>) {
     this.runtimeErrors.set(pageId, callback)
   }
 
@@ -114,7 +114,7 @@ export class PagePort implements PagePortContract {
   }
 
   emitError(pageIds: string[], error: Error) {
-    return this.emit(this.runtimeErrors, pageIds, error)
+    return this.emit(this.runtimeErrors, pageIds, error.message)
   }
 
   supplyHistory(pageId: string, request: HistorySupplyRequest): Promise<HistorySupplyResult | null> {

--- a/src/runtime/Server.test.ts
+++ b/src/runtime/Server.test.ts
@@ -2976,7 +2976,7 @@ describe('RuntimeServer Artico per-target isolation', () => {
     await settle()
     const laterBefore = articoMessagesTo(worldRoom, 'later-ready-peer').length
     const errors: string[] = []
-    await server.onError({ pageId: 'page-a' }, (error) => errors.push(error.message))
+    await server.onError({ pageId: 'page-a' }, (message) => errors.push(message))
     worldRoom.loseReadiness('closing-peer')
 
     await server.detachPage({ domain: OTHER_DOMAIN, pageId: 'page-b' })
@@ -3007,7 +3007,7 @@ describe('RuntimeServer Artico per-target isolation', () => {
     await server.joinChatRoom({ domain: DOMAIN, user: USER, site: SITE })
     await settle()
     const errors: string[] = []
-    await server.onError({ pageId: 'page-a' }, (error) => errors.push(error.message))
+    await server.onError({ pageId: 'page-a' }, (message) => errors.push(message))
     runtimeArticoFixture.nextJoins.set(worldRoomId, {
       peers: ['closing-peer', 'later-ready-peer'],
       closing: ['closing-peer']


### PR DESCRIPTION
## Summary

- send Runtime failures across the extension transport as message strings
- reconstruct Error objects at the content-side RuntimeChatRoom boundary
- cover Chrome JSON serialization and downstream domain delivery

## Verification

- pnpm test (60 files, 551 tests)
- pnpm check
- pnpm format:check
- pnpm lint:check (0 errors, 28 existing warnings)
- NODE_ENV=production pnpm build:chrome
- NODE_ENV=production pnpm build:firefox