### PR TITLE
chore(release): promote develop to master

### DIFF
--- a/openspec/changes/show-initial-message-list-at-latest-message/.openspec.yaml
+++ b/openspec/changes/show-initial-message-list-at-latest-message/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/show-initial-message-list-at-latest-message/README.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/README.md
@@ -1,0 +1,3 @@
+# show-initial-message-list-at-latest-message
+
+Show canonical chat history at the latest message on its first visible frame without an initial top-to-bottom scroll, then follow later appends only when the user was already at the bottom.

--- a/openspec/changes/show-initial-message-list-at-latest-message/design.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/design.md
@@ -49,17 +49,15 @@ After the stable first mount, Virtuoso's live follow callback uses the `isAtBott
 
 Initial history application is not a live append. Later text, notice, and grouped-row updates retain their existing canonical projection and use the same bottom-aware decision without message-type exceptions.
 
-### 5. Align short histories natively within the actual viewport
+### 5. Leave short histories without forced alignment
 
-A complete non-empty history that fits within the actual viewport still ends at the latest message. Virtuoso's native `alignToBottom` provides that end alignment on the same mounted list. Because the real scroll parent in this composition can be shorter than the actual viewport, the MessageList composition may declare one static minimum used block-size equal to the actual viewport height for the list, giving the native alignment the full viewport height to consume.
-
-This is a static declarative geometry declaration inside the existing composition. It adds no node, owner, observer, DOM measurement read, runtime height computation, correction loop, wrapper, key, or shared ScrollArea change, and it leaves the overflow case to the same last-item/end-aligned initial location.
+A complete non-empty history that fits within the actual viewport simply presents its records from their natural position. No `alignToBottom`, minimum block-size declaration, or settlement scroll forces such a history to the viewport bottom; the requirement is only that initialization presents its first frame without scrolling.
 
 ### 6. Verify the real composition boundary
 
 Deterministic component controls prove that Virtuoso is absent while either prerequisite is missing, mounts once with complete records and the real viewport when both exist, and remains mounted as records update. Browser Mode controls use the real Radix ScrollArea and Virtuoso composition to prove a first non-empty frame already at the end with no live-follow smooth decision or visible top-to-bottom motion.
 
-The same controls cover empty and short histories (with the short history's latest row at the viewport bottom), overflowing variable-height and grouped rows, one later append at the bottom, and one later append while reading above the bottom. Structural controls exclude extra readiness/position state, positioning effects, timers, animation-frame workarounds, imperative scrolling, CSS visibility gates, observers, runtime height correction loops, data-driven remount keys, and dependency changes.
+The same controls cover empty and short histories (presented without forced end alignment or settlement scroll), overflowing variable-height and grouped rows, one later append at the bottom, and one later append while reading above the bottom. Structural controls exclude extra readiness/position state, positioning effects, timers, animation-frame workarounds, imperative scrolling, CSS visibility gates, observers, runtime height correction loops, data-driven remount keys, and dependency changes.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/design.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/design.md
@@ -49,11 +49,17 @@ After the stable first mount, Virtuoso's live follow callback uses the `isAtBott
 
 Initial history application is not a live append. Later text, notice, and grouped-row updates retain their existing canonical projection and use the same bottom-aware decision without message-type exceptions.
 
-### 5. Verify the real composition boundary
+### 5. Align short histories natively within the actual viewport
+
+A complete non-empty history that fits within the actual viewport still ends at the latest message. Virtuoso's native `alignToBottom` provides that end alignment on the same mounted list. Because the real scroll parent in this composition can be shorter than the actual viewport, the MessageList composition may declare one static minimum used block-size equal to the actual viewport height for the list, giving the native alignment the full viewport height to consume.
+
+This is a static declarative geometry declaration inside the existing composition. It adds no node, owner, observer, DOM measurement read, runtime height computation, correction loop, wrapper, key, or shared ScrollArea change, and it leaves the overflow case to the same last-item/end-aligned initial location.
+
+### 6. Verify the real composition boundary
 
 Deterministic component controls prove that Virtuoso is absent while either prerequisite is missing, mounts once with complete records and the real viewport when both exist, and remains mounted as records update. Browser Mode controls use the real Radix ScrollArea and Virtuoso composition to prove a first non-empty frame already at the end with no live-follow smooth decision or visible top-to-bottom motion.
 
-The same controls cover empty and short histories, overflowing variable-height and grouped rows, one later append at the bottom, and one later append while reading above the bottom. Structural controls exclude extra readiness/position state, positioning effects, timers, animation-frame workarounds, imperative scrolling, CSS visibility gates, data-driven remount keys, and dependency changes.
+The same controls cover empty and short histories (with the short history's latest row at the viewport bottom), overflowing variable-height and grouped rows, one later append at the bottom, and one later append while reading above the bottom. Structural controls exclude extra readiness/position state, positioning effects, timers, animation-frame workarounds, imperative scrolling, CSS visibility gates, observers, runtime height correction loops, data-driven remount keys, and dependency changes.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/design.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/design.md
@@ -25,9 +25,11 @@ The list therefore needs one stable mount boundary: history readiness and the re
 
 ### 1. Join the two existing prerequisites at one mount boundary
 
-The existing `messageListLoadFinished` value remains the sole history-ready fact. The existing MessageList/ScrollArea composition retains one callback-ref-backed `HTMLElement | null` handle for the current Radix viewport. The handle represents DOM resource identity; it is not a second loading or scroll-position truth.
+The existing `messageListLoadFinished` value remains the sole history-ready truth and is consumed only at the business composition layer. That layer renders `null` instead of records while loading and the complete records (an empty list when the history is empty) once ready. The presentational message-list UI stays pure: it receives no readiness prop or equivalent business fact, and mounts Virtuoso only when its content is non-null and the callback-ref viewport handle is non-null. `null` (loading) and an empty list (ready) are explicitly distinct values; readiness is never encoded through record truthiness.
 
-Virtuoso mounts only when history loading is finished and that handle is non-null. A plain mutable ref cannot act as the gate because ref assignment alone does not schedule the render that makes both prerequisites observable. No additional `initialized`, `firstLoad`, `hasPositioned`, or equivalent fact participates.
+The existing MessageList/ScrollArea composition retains one callback-ref-backed `HTMLElement | null` handle for the current Radix viewport. The handle represents DOM resource identity; it is not a second loading or scroll-position truth.
+
+A plain mutable ref cannot act as the gate because ref assignment alone does not schedule the render that makes both prerequisites observable. No additional `initialized`, `firstLoad`, `hasPositioned`, or equivalent fact participates.
 
 The ScrollArea shell and viewport remain under their existing owner while the list is gated. The absent list adds no visible loading surface and changes no shell geometry.
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/design.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Canonical records and the existing `messageListLoadFinished` fact own message-history readiness. The existing Radix ScrollArea owns the real viewport DOM resource. Virtuoso's initial item location applies only when the list mounts, while its follow behavior applies to later data changes.
+
+The list therefore needs one stable mount boundary: history readiness and the real viewport must both exist before Virtuoso first receives canonical records. Initial positioning must not be implemented as a later live append or as another scrolling lifecycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Present the first non-empty message-list frame already aligned at the latest canonical message with no visible top-to-bottom motion.
+- Use `messageListLoadFinished` as the only history-ready truth and one callback-ref viewport handle as the only scroll-parent resource identity.
+- Keep the ScrollArea shell present while either prerequisite is unavailable, without adding visible loading feedback.
+- Smooth-follow later appends only when the user was already at the bottom and preserve the reading position otherwise.
+- Keep one mounted Virtuoso instance across record updates and support empty, short, long, grouped, and variable-height histories.
+
+**Non-Goals:**
+
+- Changing canonical records, ordering, grouping, row identity, storage, delivery, composer behavior, shell geometry, Runtime, protocol, permissions, or dependencies.
+- Adding an initialization boolean, positioned flag, bottom-state copy, second scroll owner, observer, timer, `requestAnimationFrame`, positioning effect, imperative `scrollToIndex`, CSS hiding, opacity gate, or data-driven remount key.
+- Replacing Radix ScrollArea, migrating to another virtualizer or a commercial package, or changing browser-specific behavior.
+- Adding a loading indicator, placeholder, skeleton, status message, setting, or other UI.
+
+## Decisions
+
+### 1. Join the two existing prerequisites at one mount boundary
+
+The existing `messageListLoadFinished` value remains the sole history-ready fact. The existing MessageList/ScrollArea composition retains one callback-ref-backed `HTMLElement | null` handle for the current Radix viewport. The handle represents DOM resource identity; it is not a second loading or scroll-position truth.
+
+Virtuoso mounts only when history loading is finished and that handle is non-null. A plain mutable ref cannot act as the gate because ref assignment alone does not schedule the render that makes both prerequisites observable. No additional `initialized`, `firstLoad`, `hasPositioned`, or equivalent fact participates.
+
+The ScrollArea shell and viewport remain under their existing owner while the list is gated. The absent list adds no visible loading surface and changes no shell geometry.
+
+### 2. Make the first mount the initial positioning event
+
+The first Virtuoso mount receives the complete current canonical records, the non-null viewport as `customScrollParent`, and the existing last-item/end-aligned initial location. Its first non-empty presented frame is therefore already at the latest message. Initialization does not invoke smooth live following and produces no visible top-to-bottom scroll, sweep, or intermediate top position.
+
+This mount is the only initial-positioning event for that viewport resource. It requires no effect, timer, animation frame, imperative scroll command, hidden render, opacity transition, estimated-height workaround, or separate settlement state.
+
+### 3. Keep one list identity after mount
+
+Canonical record updates do not change the mounted list's key or otherwise remount it. Grouping, row keys, measurement ownership, and the scroll parent keep their existing identities. Only actual destruction or replacement of the Radix viewport resource may remove the list and allow the same two-prerequisite boundary to mount it against the new viewport.
+
+An empty canonical history mounts after both prerequisites are ready. Its first later message enters through normal live append behavior rather than creating another initialization branch or remount.
+
+### 4. Let Virtuoso's bottom fact decide later following
+
+After the stable first mount, Virtuoso's live follow callback uses the `isAtBottom` fact supplied for that append. It returns smooth following only when `isAtBottom` is true and returns no following when it is false. The application retains no duplicate bottom state and issues no automatic or imperative scroll when the user is reading above the bottom.
+
+Initial history application is not a live append. Later text, notice, and grouped-row updates retain their existing canonical projection and use the same bottom-aware decision without message-type exceptions.
+
+### 5. Verify the real composition boundary
+
+Deterministic component controls prove that Virtuoso is absent while either prerequisite is missing, mounts once with complete records and the real viewport when both exist, and remains mounted as records update. Browser Mode controls use the real Radix ScrollArea and Virtuoso composition to prove a first non-empty frame already at the end with no live-follow smooth decision or visible top-to-bottom motion.
+
+The same controls cover empty and short histories, overflowing variable-height and grouped rows, one later append at the bottom, and one later append while reading above the bottom. Structural controls exclude extra readiness/position state, positioning effects, timers, animation-frame workarounds, imperative scrolling, CSS visibility gates, data-driven remount keys, and dependency changes.
+
+## Risks / Trade-offs
+
+- [History completes before the viewport exists] -> The ScrollArea remains present and the list waits for the real viewport instead of mounting against a temporary scroll parent.
+- [The viewport exists before history completes] -> The list waits for the canonical readiness fact instead of treating later history as a live append.
+- [Row heights vary] -> The first mount uses Virtuoso's native last-item/end alignment and existing measurement ownership; no competing correction loop is introduced.
+- [A message arrives while the user reads history] -> No follow action occurs, so the user's reading position remains under their control.
+- [The actual viewport is replaced] -> Resource lifecycle may remount the list against the new real viewport using the same two prerequisites; record changes alone cannot remount it.
+
+## Open Questions
+
+None.

--- a/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
@@ -6,7 +6,7 @@ A chat with stored history should open directly at its latest message. The initi
 
 - Keep the existing ScrollArea shell present, but mount the virtual message list only after canonical history loading is complete and the actual Radix viewport exists.
 - Give the first mount the complete canonical history and the real scroll parent so its first non-empty visible frame is already aligned at the latest message with no initial top-to-bottom scroll or live-follow animation.
-- For a complete history that fits within the actual viewport, use Virtuoso's native `alignToBottom` with one static declarative minimum used block-size equal to the actual viewport height so the latest message sits at the viewport bottom.
+- Leave a complete history that fits within the actual viewport at its natural position with no forced end alignment, block-size declaration, or settlement scroll.
 - Treat initial positioning and later live appends as separate behaviors.
 - Smooth-follow a later append only when the list was already at the bottom; otherwise preserve the user's reading position.
 - Let an empty loaded history mount normally and accept its first later message without a special initialization path.
@@ -25,6 +25,6 @@ None.
 ## Impact
 
 - Affected behavior: the first visible message-list frame after canonical history loads, later appends while the user is at or away from the bottom, empty history, and scroll-viewport replacement.
-- Affected implementation: the existing MessageList/ScrollArea composition, its callback-ref viewport handle, Virtuoso's initial position and native `alignToBottom`, the static minimum used block-size declaration, and its live follow decision.
+- Affected implementation: the existing MessageList/ScrollArea composition, its callback-ref viewport handle, Virtuoso's initial position, and its live follow decision.
 - Affected verification: both readiness gates, first-frame end alignment without scrolling, bottom and non-bottom appends, empty and short histories, variable-height rows, and stable list identity after mount.
 - Unchanged: canonical message data, ordering, grouping and row keys, durable history, composer behavior, shell geometry, Runtime networking, protocol, persistence, permissions, dependencies, and browser-specific product behavior.

--- a/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
@@ -5,6 +5,7 @@ A chat with stored history should open directly at its latest message. The initi
 ## What Changes
 
 - Keep the existing ScrollArea shell present, but mount the virtual message list only after canonical history loading is complete and the actual Radix viewport exists.
+- Keep the presentational message-list UI pure: the business composition layer renders `null` while loading and the complete records once ready, so the list mounts on content presence plus the real viewport without receiving any business readiness fact.
 - Give the first mount the complete canonical history and the real scroll parent so its first non-empty visible frame is already aligned at the latest message with no initial top-to-bottom scroll or live-follow animation.
 - Leave a complete history that fits within the actual viewport at its natural position with no forced end alignment, block-size declaration, or settlement scroll.
 - Treat initial positioning and later live appends as separate behaviors.

--- a/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A chat with stored history should open directly at its latest message. The initial content must not become visible at the top and then animate or sweep to the bottom, and later messages must not pull a user away from history they are reading.
+
+## What Changes
+
+- Keep the existing ScrollArea shell present, but mount the virtual message list only after canonical history loading is complete and the actual Radix viewport exists.
+- Give the first mount the complete canonical history and the real scroll parent so its first non-empty visible frame is already aligned at the latest message with no initial top-to-bottom scroll or live-follow animation.
+- Treat initial positioning and later live appends as separate behaviors.
+- Smooth-follow a later append only when the list was already at the bottom; otherwise preserve the user's reading position.
+- Let an empty loaded history mount normally and accept its first later message without a special initialization path.
+- Add no loading UI, readiness or scroll-state copy, effect-driven positioning, timer, animation-frame workaround, imperative post-mount scroll, dependency, or commercial package migration.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `webrtc-runtime`: Define stable initial message-list positioning and bottom-aware live append following.
+
+## Impact
+
+- Affected behavior: the first visible message-list frame after canonical history loads, later appends while the user is at or away from the bottom, empty history, and scroll-viewport replacement.
+- Affected implementation: the existing MessageList/ScrollArea composition, its callback-ref viewport handle, Virtuoso's initial position, and its live follow decision.
+- Affected verification: both readiness gates, first-frame end alignment without scrolling, bottom and non-bottom appends, empty and short histories, variable-height rows, and stable list identity after mount.
+- Unchanged: canonical message data, ordering, grouping and row keys, durable history, composer behavior, shell geometry, Runtime networking, protocol, persistence, permissions, dependencies, and browser-specific product behavior.

--- a/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/proposal.md
@@ -6,6 +6,7 @@ A chat with stored history should open directly at its latest message. The initi
 
 - Keep the existing ScrollArea shell present, but mount the virtual message list only after canonical history loading is complete and the actual Radix viewport exists.
 - Give the first mount the complete canonical history and the real scroll parent so its first non-empty visible frame is already aligned at the latest message with no initial top-to-bottom scroll or live-follow animation.
+- For a complete history that fits within the actual viewport, use Virtuoso's native `alignToBottom` with one static declarative minimum used block-size equal to the actual viewport height so the latest message sits at the viewport bottom.
 - Treat initial positioning and later live appends as separate behaviors.
 - Smooth-follow a later append only when the list was already at the bottom; otherwise preserve the user's reading position.
 - Let an empty loaded history mount normally and accept its first later message without a special initialization path.
@@ -24,6 +25,6 @@ None.
 ## Impact
 
 - Affected behavior: the first visible message-list frame after canonical history loads, later appends while the user is at or away from the bottom, empty history, and scroll-viewport replacement.
-- Affected implementation: the existing MessageList/ScrollArea composition, its callback-ref viewport handle, Virtuoso's initial position, and its live follow decision.
+- Affected implementation: the existing MessageList/ScrollArea composition, its callback-ref viewport handle, Virtuoso's initial position and native `alignToBottom`, the static minimum used block-size declaration, and its live follow decision.
 - Affected verification: both readiness gates, first-frame end alignment without scrolling, bottom and non-bottom appends, empty and short histories, variable-height rows, and stable list identity after mount.
 - Unchanged: canonical message data, ordering, grouping and row keys, durable history, composer behavior, shell geometry, Runtime networking, protocol, persistence, permissions, dependencies, and browser-specific product behavior.

--- a/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
@@ -6,6 +6,8 @@ The existing ScrollArea shell SHALL remain present while the virtual message lis
 
 When both prerequisites exist, Virtuoso SHALL mount once with the complete current canonical records, that non-null viewport as its real custom scroll parent, and a last-item/end-aligned initial location. The first non-empty message-list frame presented to the user SHALL already be aligned at the latest canonical message. It SHALL NOT first present the top of history, animate or sweep from top to bottom, or use live-follow smooth scrolling to settle initial history.
 
+When the complete non-empty history fits within the actual viewport, Virtuoso SHALL use its native `alignToBottom` behavior for that end alignment, and the existing MessageList composition MAY declare one static minimum used block-size equal to the actual viewport height for the list so the latest message aligns to the viewport bottom. That declaration SHALL be static and declarative within the existing composition: it SHALL NOT add an observer, DOM measurement read, runtime height computation, correction loop, wrapper node, or shared ScrollArea change.
+
 Canonical record updates SHALL NOT change the mounted Virtuoso key or otherwise remount it. Only actual destruction or replacement of the Radix viewport resource MAY remove the list and re-enter the same two-prerequisite mount boundary. An empty canonical history SHALL mount normally after both prerequisites exist and SHALL accept its first later message through the normal append behavior.
 
 This behavior SHALL add no loading UI, placeholder, skeleton, status copy, initialization observer, bottom-state copy, positioning effect, timer, `requestAnimationFrame`, imperative scroll command, CSS visibility or opacity gate, height-correction loop, alternative scroll parent, virtualizer migration, dependency, or commercial package. Canonical message data, ordering, grouping, row identity, durable history, composer behavior, shell geometry, Runtime networking, protocol, persistence, permissions, and browser-independent product behavior SHALL remain unchanged.
@@ -32,7 +34,7 @@ This behavior SHALL add no loading UI, placeholder, skeleton, status copy, initi
 
 - **GIVEN** a complete non-empty canonical history fits within the actual Radix viewport
 - **WHEN** Virtuoso first mounts
-- **THEN** the latest message SHALL already be presented at the end alignment and initialization SHALL issue no automatic or imperative settlement scroll
+- **THEN** the latest message SHALL already be presented at the viewport bottom through the native `alignToBottom` behavior and the static minimum used block-size, and initialization SHALL issue no automatic or imperative settlement scroll
 
 #### Scenario: Empty history mounts once and accepts its first message
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
@@ -4,6 +4,8 @@
 
 The existing ScrollArea shell SHALL remain present while the virtual message list waits for its two existing prerequisites: canonical `messageListLoadFinished` history readiness and a non-null handle for the actual Radix viewport. Virtuoso SHALL NOT mount while either prerequisite is unavailable. History readiness SHALL remain the sole loading fact, and one callback-ref-backed `HTMLElement | null` viewport handle SHALL remain the sole scroll-parent resource identity. WebChat SHALL NOT add another initialized, first-load, positioned, or equivalent readiness fact.
 
+The canonical history-readiness fact SHALL be consumed only at the business composition layer, which SHALL express it as the list's content: while loading it SHALL render `null` instead of records, and once ready it SHALL render the complete records (an empty list when the history is empty). The presentational message-list UI SHALL NOT receive, prop-drill, or otherwise consume that business readiness fact. It SHALL keep Virtuoso absent while its content is `null` and SHALL mount Virtuoso once when content (including an empty list) and the real viewport both exist. A `null` loading value and an empty ready list SHALL remain explicitly distinct values; readiness SHALL NOT be encoded through truthiness of the records themselves.
+
 When both prerequisites exist, Virtuoso SHALL mount once with the complete current canonical records, that non-null viewport as its real custom scroll parent, and a last-item/end-aligned initial location. The first non-empty message-list frame presented to the user SHALL already be aligned at the latest canonical message. It SHALL NOT first present the top of history, animate or sweep from top to bottom, or use live-follow smooth scrolling to settle initial history.
 
 A complete non-empty history that fits within the actual viewport SHALL simply present its records without any settlement scroll; WebChat SHALL NOT add alignment styling, minimum block-size declarations, or imperative scrolling to force short histories to the viewport bottom.
@@ -47,6 +49,12 @@ This behavior SHALL add no loading UI, placeholder, skeleton, status copy, initi
 - **GIVEN** Virtuoso is mounted against the current actual viewport
 - **WHEN** canonical records append, group, or otherwise reproject under their existing rules
 - **THEN** the list and scroll-parent identities SHALL remain stable and the update SHALL NOT re-enter initial positioning
+
+#### Scenario: Business layer alone owns the readiness gate
+
+- **GIVEN** canonical history is loading or ready
+- **WHEN** the business composition layer renders the MessageList composition
+- **THEN** it SHALL pass `null` while loading and the complete records once ready, the presentational list UI SHALL receive no readiness prop or equivalent business fact, and Virtuoso SHALL mount only when content is non-null and the real viewport exists
 
 #### Scenario: Actual viewport replacement owns remounting
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: Initial canonical history appears at the latest message without scrolling into place
+
+The existing ScrollArea shell SHALL remain present while the virtual message list waits for its two existing prerequisites: canonical `messageListLoadFinished` history readiness and a non-null handle for the actual Radix viewport. Virtuoso SHALL NOT mount while either prerequisite is unavailable. History readiness SHALL remain the sole loading fact, and one callback-ref-backed `HTMLElement | null` viewport handle SHALL remain the sole scroll-parent resource identity. WebChat SHALL NOT add another initialized, first-load, positioned, or equivalent readiness fact.
+
+When both prerequisites exist, Virtuoso SHALL mount once with the complete current canonical records, that non-null viewport as its real custom scroll parent, and a last-item/end-aligned initial location. The first non-empty message-list frame presented to the user SHALL already be aligned at the latest canonical message. It SHALL NOT first present the top of history, animate or sweep from top to bottom, or use live-follow smooth scrolling to settle initial history.
+
+Canonical record updates SHALL NOT change the mounted Virtuoso key or otherwise remount it. Only actual destruction or replacement of the Radix viewport resource MAY remove the list and re-enter the same two-prerequisite mount boundary. An empty canonical history SHALL mount normally after both prerequisites exist and SHALL accept its first later message through the normal append behavior.
+
+This behavior SHALL add no loading UI, placeholder, skeleton, status copy, initialization observer, bottom-state copy, positioning effect, timer, `requestAnimationFrame`, imperative scroll command, CSS visibility or opacity gate, height-correction loop, alternative scroll parent, virtualizer migration, dependency, or commercial package. Canonical message data, ordering, grouping, row identity, durable history, composer behavior, shell geometry, Runtime networking, protocol, persistence, permissions, and browser-independent product behavior SHALL remain unchanged.
+
+#### Scenario: History readiness alone does not mount the list
+
+- **GIVEN** canonical history loading is complete and the actual Radix viewport handle is null
+- **WHEN** the MessageList composition renders
+- **THEN** the ScrollArea shell SHALL remain present, Virtuoso SHALL remain absent, and no temporary scroll parent or visible loading UI SHALL appear
+
+#### Scenario: Viewport readiness alone does not mount the list
+
+- **GIVEN** the actual Radix viewport exists and canonical history loading is not complete
+- **WHEN** the MessageList composition renders
+- **THEN** Virtuoso SHALL remain absent and the available viewport SHALL NOT turn later history application into a live-follow append
+
+#### Scenario: Complete history first appears at the latest message
+
+- **GIVEN** an overflowing canonical history with variable-height text, notice, or grouped rows is complete and the actual Radix viewport exists
+- **WHEN** Virtuoso first mounts
+- **THEN** it SHALL receive the complete records and non-null real scroll parent, its first non-empty presented frame SHALL already be end-aligned at the latest canonical message, and no initial live-follow smooth decision or visible top-to-bottom motion SHALL occur
+
+#### Scenario: Short history is end-aligned without a settlement scroll
+
+- **GIVEN** a complete non-empty canonical history fits within the actual Radix viewport
+- **WHEN** Virtuoso first mounts
+- **THEN** the latest message SHALL already be presented at the end alignment and initialization SHALL issue no automatic or imperative settlement scroll
+
+#### Scenario: Empty history mounts once and accepts its first message
+
+- **GIVEN** canonical history loading completes with no records and the actual Radix viewport exists
+- **WHEN** Virtuoso mounts and a first new message later arrives
+- **THEN** the same mounted list SHALL accept that message through normal append behavior without another initialization fact, remount, or positioning path
+
+#### Scenario: Record updates preserve the mounted list
+
+- **GIVEN** Virtuoso is mounted against the current actual viewport
+- **WHEN** canonical records append, group, or otherwise reproject under their existing rules
+- **THEN** the list and scroll-parent identities SHALL remain stable and the update SHALL NOT re-enter initial positioning
+
+#### Scenario: Actual viewport replacement owns remounting
+
+- **GIVEN** Virtuoso is mounted and the owning Radix viewport resource is destroyed or replaced
+- **WHEN** the callback-ref handle reflects that resource lifecycle
+- **THEN** the list MAY unmount while the handle is null and SHALL mount against only the new non-null viewport after canonical history remains ready, without a data-driven remount key or stale scroll parent
+
+### Requirement: Later appends follow only from the bottom
+
+After the stable initial mount, each later canonical append SHALL use Virtuoso's supplied `isAtBottom` fact directly. When that fact is true, the append SHALL smooth-follow the latest message. When it is false, the append SHALL perform no follow action and SHALL preserve the user's current history-reading position.
+
+WebChat SHALL NOT return an automatic follow result for the non-bottom case, issue an imperative scroll, retain a duplicate bottom-state owner, or add message-type exceptions. Text, notice, and grouped-row appends SHALL use the same decision after their unchanged canonical projection. Initial history application SHALL NOT be treated as a later append.
+
+#### Scenario: Append at the bottom follows smoothly
+
+- **GIVEN** the stable message list is mounted and the user is at the bottom immediately before a later canonical append
+- **WHEN** the append reaches Virtuoso
+- **THEN** the list SHALL smooth-follow the latest message through the existing live follow boundary
+
+#### Scenario: Append while reading history preserves position
+
+- **GIVEN** the stable message list is mounted and the user is above the bottom reading earlier messages immediately before a later canonical append
+- **WHEN** the append reaches Virtuoso
+- **THEN** the list SHALL perform no follow action, preserve the user's reading position, and SHALL NOT jump or animate to the bottom
+
+#### Scenario: Message kind does not change the follow rule
+
+- **GIVEN** a later text, notice, or grouped-row update reaches the mounted list
+- **WHEN** Virtuoso supplies the current bottom fact
+- **THEN** WebChat SHALL smooth-follow only for true and perform no follow action for false without a message-kind branch or copied bottom state
+
+#### Scenario: Initial history never enters live following
+
+- **GIVEN** canonical history and the actual viewport become ready for the first mount
+- **WHEN** the complete history is presented at its initial last-item/end-aligned location
+- **THEN** WebChat SHALL use only the initial positioning boundary and SHALL NOT invoke smooth live following to reach the latest message

--- a/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/specs/webrtc-runtime/spec.md
@@ -6,7 +6,7 @@ The existing ScrollArea shell SHALL remain present while the virtual message lis
 
 When both prerequisites exist, Virtuoso SHALL mount once with the complete current canonical records, that non-null viewport as its real custom scroll parent, and a last-item/end-aligned initial location. The first non-empty message-list frame presented to the user SHALL already be aligned at the latest canonical message. It SHALL NOT first present the top of history, animate or sweep from top to bottom, or use live-follow smooth scrolling to settle initial history.
 
-When the complete non-empty history fits within the actual viewport, Virtuoso SHALL use its native `alignToBottom` behavior for that end alignment, and the existing MessageList composition MAY declare one static minimum used block-size equal to the actual viewport height for the list so the latest message aligns to the viewport bottom. That declaration SHALL be static and declarative within the existing composition: it SHALL NOT add an observer, DOM measurement read, runtime height computation, correction loop, wrapper node, or shared ScrollArea change.
+A complete non-empty history that fits within the actual viewport SHALL simply present its records without any settlement scroll; WebChat SHALL NOT add alignment styling, minimum block-size declarations, or imperative scrolling to force short histories to the viewport bottom.
 
 Canonical record updates SHALL NOT change the mounted Virtuoso key or otherwise remount it. Only actual destruction or replacement of the Radix viewport resource MAY remove the list and re-enter the same two-prerequisite mount boundary. An empty canonical history SHALL mount normally after both prerequisites exist and SHALL accept its first later message through the normal append behavior.
 
@@ -30,11 +30,11 @@ This behavior SHALL add no loading UI, placeholder, skeleton, status copy, initi
 - **WHEN** Virtuoso first mounts
 - **THEN** it SHALL receive the complete records and non-null real scroll parent, its first non-empty presented frame SHALL already be end-aligned at the latest canonical message, and no initial live-follow smooth decision or visible top-to-bottom motion SHALL occur
 
-#### Scenario: Short history is end-aligned without a settlement scroll
+#### Scenario: Short history presents without a settlement scroll
 
 - **GIVEN** a complete non-empty canonical history fits within the actual Radix viewport
 - **WHEN** Virtuoso first mounts
-- **THEN** the latest message SHALL already be presented at the viewport bottom through the native `alignToBottom` behavior and the static minimum used block-size, and initialization SHALL issue no automatic or imperative settlement scroll
+- **THEN** the records SHALL present without end-alignment styling or block-size declarations, and initialization SHALL issue no automatic or imperative settlement scroll
 
 #### Scenario: Empty history mounts once and accepts its first message
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -8,7 +8,7 @@
 ## 2. Implementation
 
 - [ ] 2.1 Retain one callback-ref-backed viewport handle in the existing MessageList/ScrollArea composition and gate Virtuoso on that handle plus `messageListLoadFinished`, without another readiness or scroll-position fact.
-- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; for a complete history that fits within the actual viewport, use native `alignToBottom` plus one static declarative minimum used block-size equal to the actual viewport height so the latest message sits at the viewport bottom.
+- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; a complete history that fits within the actual viewport presents at its natural position with no `alignToBottom`, block-size declaration, or settlement scroll.
 - [ ] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
 - [ ] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.
 - [ ] 2.5 Add focused component and Browser Mode regressions for both readiness gates, first-frame end alignment without initial scrolling, bottom and non-bottom appends, empty and short histories, variable-height/grouped rows, and stable post-mount identity.

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -7,12 +7,12 @@
 
 ## 2. Implementation
 
-- [ ] 2.1 Consume `messageListLoadFinished` only at the business composition layer, rendering `null` while loading and the complete records once ready; keep the presentational list UI free of any readiness prop, gate Virtuoso on non-null content plus the non-null callback-ref viewport handle, and add no other readiness or scroll-position fact.
-- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; a complete history that fits within the actual viewport presents at its natural position with no `alignToBottom`, block-size declaration, or settlement scroll.
-- [ ] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
-- [ ] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.
-- [ ] 2.5 Add focused component and Browser Mode regressions for both readiness gates, first-frame end alignment without initial scrolling, bottom and non-bottom appends, empty and short histories, variable-height/grouped rows, and stable post-mount identity.
-- [ ] 2.6 Add structural controls excluding extra initialization/bottom state, positioning effects, timers, animation frames, imperative scroll commands, CSS hiding, observers, runtime height correction loops, data-driven remount keys, new UI, and dependency changes.
+- [x] 2.1 Consume `messageListLoadFinished` only at the business composition layer, rendering `null` while loading and the complete records once ready; keep the presentational list UI free of any readiness prop, gate Virtuoso on non-null content plus the non-null callback-ref viewport handle, and add no other readiness or scroll-position fact.
+- [x] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; a complete history that fits within the actual viewport presents at its natural position with no `alignToBottom`, block-size declaration, or settlement scroll.
+- [x] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
+- [x] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.
+- [x] 2.5 Add focused component and Browser Mode regressions for both readiness gates, first-frame end alignment without initial scrolling, bottom and non-bottom appends, empty and short histories, variable-height/grouped rows, and stable post-mount identity.
+- [x] 2.6 Add structural controls excluding extra initialization/bottom state, positioning effects, timers, animation frames, imperative scroll commands, CSS hiding, observers, runtime height correction loops, data-driven remount keys, new UI, and dependency changes.
 
 ## 3. Verification and Delivery
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -1,0 +1,23 @@
+## 1. Product Contract
+
+- [x] 1.1 Define the first non-empty message-list frame as already end-aligned at the latest canonical message with no visible top-to-bottom scroll or live-follow animation.
+- [x] 1.2 Define canonical history readiness plus the actual Radix viewport as the only prerequisites for the first Virtuoso mount.
+- [x] 1.3 Define later smooth following only when the user was already at the bottom, with reading position preserved otherwise.
+- [x] 1.4 Define empty-history behavior, stable post-mount list identity, viewport resource lifecycle, unchanged UI, and protected data/runtime boundaries.
+
+## 2. Implementation
+
+- [ ] 2.1 Retain one callback-ref-backed viewport handle in the existing MessageList/ScrollArea composition and gate Virtuoso on that handle plus `messageListLoadFinished`, without another readiness or scroll-position fact.
+- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged.
+- [ ] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
+- [ ] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.
+- [ ] 2.5 Add focused component and Browser Mode regressions for both readiness gates, first-frame end alignment without initial scrolling, bottom and non-bottom appends, empty and short histories, variable-height/grouped rows, and stable post-mount identity.
+- [ ] 2.6 Add structural controls excluding extra initialization/bottom state, positioning effects, timers, animation frames, imperative scroll commands, CSS hiding, data-driven remount keys, new UI, and dependency changes.
+
+## 3. Verification and Delivery
+
+- [ ] 3.1 Freeze one clean implementation exact as the sole child of this PM authority exact and pass the focused/full Vitest, TypeScript, format, lint, strict OpenSpec/status/doctor, React Doctor, dual production-build, scope, identity, and current-only gates required by the repository.
+- [ ] 3.2 Obtain a fresh architecture-first Reviewer verdict on the same exact, including the complete mount/scroll owner graph, stable viewport/list identity, native initial positioning, bottom-aware live following, and every protected boundary.
+- [ ] 3.3 Publish the reviewed exact through one independent requirement branch and Draft PR based on `develop`, collect fresh CI, release the branch from every agent worktree, and hand the directly checkout-able branch plus immutable exact to `@molvqingtai` for desktop product acceptance.
+- [ ] 3.4 Keep QA, QC, and UX absent unless the Owner explicitly requests one; record any performed or unavailable browser behavior verification truthfully without making it a source or CI blocker.
+- [ ] 3.5 After Owner acceptance, let PM immediately close final OpenSpec/task truth; then complete final identity and CI gates and only the merge authorized by that acceptance.

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -8,11 +8,11 @@
 ## 2. Implementation
 
 - [ ] 2.1 Retain one callback-ref-backed viewport handle in the existing MessageList/ScrollArea composition and gate Virtuoso on that handle plus `messageListLoadFinished`, without another readiness or scroll-position fact.
-- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged.
+- [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; for a complete history that fits within the actual viewport, use native `alignToBottom` plus one static declarative minimum used block-size equal to the actual viewport height so the latest message sits at the viewport bottom.
 - [ ] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
 - [ ] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.
 - [ ] 2.5 Add focused component and Browser Mode regressions for both readiness gates, first-frame end alignment without initial scrolling, bottom and non-bottom appends, empty and short histories, variable-height/grouped rows, and stable post-mount identity.
-- [ ] 2.6 Add structural controls excluding extra initialization/bottom state, positioning effects, timers, animation frames, imperative scroll commands, CSS hiding, data-driven remount keys, new UI, and dependency changes.
+- [ ] 2.6 Add structural controls excluding extra initialization/bottom state, positioning effects, timers, animation frames, imperative scroll commands, CSS hiding, observers, runtime height correction loops, data-driven remount keys, new UI, and dependency changes.
 
 ## 3. Verification and Delivery
 

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -16,8 +16,8 @@
 
 ## 3. Verification and Delivery
 
-- [ ] 3.1 Freeze one clean implementation exact as the sole child of this PM authority exact and pass the focused/full Vitest, TypeScript, format, lint, strict OpenSpec/status/doctor, React Doctor, dual production-build, scope, identity, and current-only gates required by the repository.
-- [ ] 3.2 Obtain a fresh architecture-first Reviewer verdict on the same exact, including the complete mount/scroll owner graph, stable viewport/list identity, native initial positioning, bottom-aware live following, and every protected boundary.
-- [ ] 3.3 Publish the reviewed exact through one independent requirement branch and Draft PR based on `develop`, collect fresh CI, release the branch from every agent worktree, and hand the directly checkout-able branch plus immutable exact to `@molvqingtai` for desktop product acceptance.
-- [ ] 3.4 Keep QA, QC, and UX absent unless the Owner explicitly requests one; record any performed or unavailable browser behavior verification truthfully without making it a source or CI blocker.
-- [ ] 3.5 After Owner acceptance, let PM immediately close final OpenSpec/task truth; then complete final identity and CI gates and only the merge authorized by that acceptance.
+- [x] 3.1 Freeze one clean implementation exact as the sole child of this PM authority exact and pass the focused/full Vitest, TypeScript, format, lint, strict OpenSpec/status/doctor, React Doctor, dual production-build, scope, identity, and current-only gates required by the repository.
+- [x] 3.2 Obtain a fresh architecture-first Reviewer verdict on the same exact, including the complete mount/scroll owner graph, stable viewport/list identity, native initial positioning, bottom-aware live following, and every protected boundary.
+- [x] 3.3 Publish the reviewed exact through one independent requirement branch and Draft PR based on `develop`, collect fresh CI, release the branch from every agent worktree, and hand the directly checkout-able branch plus immutable exact to `@molvqingtai` for desktop product acceptance.
+- [x] 3.4 Keep QA, QC, and UX absent unless the Owner explicitly requests one; record any performed or unavailable browser behavior verification truthfully without making it a source or CI blocker.
+- [x] 3.5 After Owner acceptance, let PM immediately close final OpenSpec/task truth; then complete final identity and CI gates and only the merge authorized by that acceptance.

--- a/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
+++ b/openspec/changes/show-initial-message-list-at-latest-message/tasks.md
@@ -7,7 +7,7 @@
 
 ## 2. Implementation
 
-- [ ] 2.1 Retain one callback-ref-backed viewport handle in the existing MessageList/ScrollArea composition and gate Virtuoso on that handle plus `messageListLoadFinished`, without another readiness or scroll-position fact.
+- [ ] 2.1 Consume `messageListLoadFinished` only at the business composition layer, rendering `null` while loading and the complete records once ready; keep the presentational list UI free of any readiness prop, gate Virtuoso on non-null content plus the non-null callback-ref viewport handle, and add no other readiness or scroll-position fact.
 - [ ] 2.2 First-mount Virtuoso with the complete canonical records, non-null `customScrollParent`, and last-item/end-aligned initial location while leaving the existing ScrollArea shell visible and unchanged; a complete history that fits within the actual viewport presents at its natural position with no `alignToBottom`, block-size declaration, or settlement scroll.
 - [ ] 2.3 Use the live follow callback's `isAtBottom` input directly: smooth-follow when true and perform no follow action when false.
 - [ ] 2.4 Keep the mounted list identity stable across record updates; let only actual viewport resource destruction or replacement re-enter the mount boundary, and let empty history accept its first message through normal append behavior.

--- a/src/app/content/components/message-list.browser.test.tsx
+++ b/src/app/content/components/message-list.browser.test.tsx
@@ -1,0 +1,224 @@
+import { cleanup, render } from 'vitest-browser-react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { type ReactElement } from 'react'
+import '@/assets/styles/tailwind.css'
+import { MESSAGE_RECORD_TYPE, NOTICE_TYPE, type SystemNoticeMessage } from '@/domain/Message'
+import MessageList from './message-list'
+import NoticeGroup from './notice-group'
+
+const frame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+const row = (id: string, height: number): ReactElement => (
+  <div data-testid={`message-${id}`} key={id} style={{ boxSizing: 'border-box', height, padding: '8px' }}>
+    Message {id}
+  </div>
+)
+const history = (count: number) =>
+  Array.from({ length: count }, (_, index) => row(String(index), index % 4 === 0 ? 156 : 56 + (index % 3) * 24))
+const noticeUser = { id: 'notice-user', name: 'Notice user', avatar: '' }
+const notice = (id: string, timestamp: number): SystemNoticeMessage => ({
+  type: MESSAGE_RECORD_TYPE.SYSTEM_NOTICE,
+  id,
+  hlc: { timestamp, counter: 0 },
+  receivedAt: timestamp,
+  user: noticeUser,
+  body: id,
+  noticeType: NOTICE_TYPE.INFO
+})
+const groupedRow = (
+  <NoticeGroup
+    key="notice-group"
+    notices={[notice('Grouped older notice', 1), notice('Grouped latest notice', 2)]}
+    last
+  />
+)
+const harness = (historyReady: boolean, children: ReactElement[]) => (
+  <div style={{ display: 'grid', gridTemplateRows: '1fr', height: '240px', width: '360px' }}>
+    <MessageList>{historyReady ? children : null}</MessageList>
+  </div>
+)
+const viewport = () => document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
+const list = () => document.querySelector<HTMLElement>('[data-testid="virtuoso-item-list"]')
+const atBottom = (element: HTMLElement) => element.scrollTop + element.clientHeight >= element.scrollHeight - 1
+type ScrollCall = ScrollToOptions | readonly [number, number | undefined]
+const isScrollOptions = (call: ScrollCall): call is ScrollToOptions => !Array.isArray(call)
+const suppressResizeObserverLoop = (event: ErrorEvent) => {
+  if (event.message === 'ResizeObserver loop completed with undelivered notifications.') event.preventDefault()
+}
+
+beforeEach(() => window.addEventListener('error', suppressResizeObserverLoop))
+afterEach(() => {
+  window.removeEventListener('error', suppressResizeObserverLoop)
+  cleanup()
+})
+
+describe('MessageList initial settlement', () => {
+  it('first presents overflowing variable-height history at the end without a smooth settlement scroll', async () => {
+    const rows = [...history(23), groupedRow]
+    const view = await render(harness(false, rows))
+
+    expect(list()).toBeNull()
+
+    const scrollParent = viewport()
+    const calls: ScrollCall[] = []
+    const originalScrollTo = scrollParent.scrollTo
+    const originalScrollBy = scrollParent.scrollBy
+    scrollParent.scrollTo = ((...args: [ScrollToOptions] | [number, number]) => {
+      const first = args[0]
+      calls.push(typeof first === 'object' ? { ...first } : ([first, args[1]] as const))
+      if (typeof first === 'object') {
+        return Reflect.apply(originalScrollTo, scrollParent, [{ ...first, behavior: 'auto' }])
+      }
+      return Reflect.apply(originalScrollTo, scrollParent, args)
+    }) as typeof scrollParent.scrollTo
+    scrollParent.scrollBy = ((...args: [ScrollToOptions] | [number, number]) => {
+      const first = args[0]
+      calls.push(typeof first === 'object' ? { ...first } : ([first, args[1]] as const))
+      if (typeof first === 'object') {
+        return Reflect.apply(originalScrollBy, scrollParent, [{ ...first, behavior: 'auto' }])
+      }
+      return Reflect.apply(originalScrollBy, scrollParent, args)
+    }) as typeof scrollParent.scrollBy
+
+    const visibleOffsets: number[] = []
+    let sampling = true
+    const sample = () => {
+      const currentList = list()
+      if (currentList && getComputedStyle(currentList).visibility !== 'hidden') {
+        visibleOffsets.push(scrollParent.scrollTop)
+      }
+      if (sampling) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+
+    await view.rerender(harness(true, rows))
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Grouped latest notice')
+      expect(document.body.textContent).not.toContain('Grouped older notice')
+      expect(atBottom(scrollParent)).toBe(true)
+      expect(visibleOffsets.length).toBeGreaterThan(0)
+    })
+    sampling = false
+
+    expect(visibleOffsets.every((offset) => offset + scrollParent.clientHeight >= scrollParent.scrollHeight - 1)).toBe(
+      true
+    )
+    expect(calls.some((call) => isScrollOptions(call) && call.behavior === 'smooth')).toBe(false)
+  })
+
+  it('follows an append when the user is already at the bottom', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await frame()
+    await frame()
+    const bottomBeforeAppend = scrollParent.scrollTop
+
+    await view.rerender(harness(true, [...initialRows, row('bottom-append', 72)]))
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-bottom-append"]')).not.toBeNull()
+      expect(scrollParent.scrollTop).toBeGreaterThan(bottomBeforeAppend)
+      expect(atBottom(scrollParent)).toBe(true)
+    })
+  })
+
+  it('preserves a non-bottom reading position when a message arrives', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-23"]')).not.toBeNull()
+      expect(getComputedStyle(list()!).visibility).not.toBe('hidden')
+      expect(atBottom(scrollParent)).toBe(true)
+    })
+    await frame()
+    await frame()
+
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => {
+      expect(scrollParent.scrollTop).toBe(0)
+      expect(document.querySelector('[data-testid="message-0"]')).not.toBeNull()
+    })
+    await frame()
+    await frame()
+    const scrollHeightBeforeAppend = scrollParent.scrollHeight
+
+    await view.rerender(harness(true, [...initialRows, row('history-append', 88)]))
+    await vi.waitFor(() => expect(scrollParent.scrollHeight).toBeGreaterThan(scrollHeightBeforeAppend))
+    await frame()
+    await frame()
+
+    expect(scrollParent.scrollTop).toBe(0)
+  })
+
+  it('first presents a non-empty short history at its natural position without a settlement scroll', async () => {
+    const rows = [row('short-first', 48), row('short-latest', 64)]
+    const view = await render(harness(false, rows))
+
+    expect(list()).toBeNull()
+
+    const scrollParent = viewport()
+    const calls: ScrollCall[] = []
+    const originalScrollTo = scrollParent.scrollTo
+    const originalScrollBy = scrollParent.scrollBy
+    scrollParent.scrollTo = ((...args: [ScrollToOptions] | [number, number]) => {
+      const first = args[0]
+      calls.push(typeof first === 'object' ? { ...first } : ([first, args[1]] as const))
+      if (typeof first === 'object') {
+        return Reflect.apply(originalScrollTo, scrollParent, [{ ...first, behavior: 'auto' }])
+      }
+      return Reflect.apply(originalScrollTo, scrollParent, args)
+    }) as typeof scrollParent.scrollTo
+    scrollParent.scrollBy = ((...args: [ScrollToOptions] | [number, number]) => {
+      const first = args[0]
+      calls.push(typeof first === 'object' ? { ...first } : ([first, args[1]] as const))
+      if (typeof first === 'object') {
+        return Reflect.apply(originalScrollBy, scrollParent, [{ ...first, behavior: 'auto' }])
+      }
+      return Reflect.apply(originalScrollBy, scrollParent, args)
+    }) as typeof scrollParent.scrollBy
+
+    const visibleOffsets: number[] = []
+    let sampling = true
+    const sample = () => {
+      const currentList = list()
+      if (currentList && getComputedStyle(currentList).visibility !== 'hidden') {
+        visibleOffsets.push(scrollParent.scrollTop)
+      }
+      if (sampling) requestAnimationFrame(sample)
+    }
+    requestAnimationFrame(sample)
+
+    await view.rerender(harness(true, rows))
+    await vi.waitFor(() => {
+      const first = document.querySelector<HTMLElement>('[data-testid="message-short-first"]')
+      const latest = document.querySelector<HTMLElement>('[data-testid="message-short-latest"]')
+      const viewportBounds = viewport().getBoundingClientRect()
+      expect(first).not.toBeNull()
+      expect(latest).not.toBeNull()
+      expect(Math.abs(first!.getBoundingClientRect().top - viewportBounds.top)).toBeLessThan(1)
+      expect(latest!.getBoundingClientRect().bottom).toBeLessThanOrEqual(viewportBounds.bottom)
+      expect(visibleOffsets.length).toBeGreaterThan(0)
+    })
+    sampling = false
+
+    expect(visibleOffsets.every((offset) => offset === 0)).toBe(true)
+    expect(calls).toHaveLength(0)
+  })
+
+  it('mounts loaded empty history once and accepts its first append without replacement', async () => {
+    const view = await render(harness(true, []))
+    await vi.waitFor(() => expect(list()).not.toBeNull())
+    const mountedList = list()
+
+    await view.rerender(harness(true, [row('first', 48)]))
+    await vi.waitFor(() => expect(document.querySelector('[data-testid="message-first"]')).not.toBeNull())
+
+    expect(list()).toBe(mountedList)
+    expect(atBottom(viewport())).toBe(true)
+  })
+})

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -1,7 +1,8 @@
-import { createElement, type ReactElement } from 'react'
+import { createElement, useEffect, type ReactElement, type Ref } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { act, cleanup, render } from '@testing-library/react'
 import type { VirtuosoProps } from 'react-virtuoso'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MESSAGE_RECORD_TYPE, NOTICE_TYPE, type DisplayMessage, type SystemNoticeMessage } from '@/domain/Message'
 import MessageList from './message-list'
 import NoticeGroup from './notice-group'
@@ -9,21 +10,57 @@ import { groupAdjacentNotices, messageRowKey, type GroupedMessage } from './noti
 import NoticeItem from './notice-item'
 
 interface VirtuosoCall {
+  alignToBottom?: boolean
+  customScrollParent?: HTMLElement
+  data: readonly ReactElement[]
+  followOutput?: VirtuosoProps<ReactElement, unknown>['followOutput']
+  initialTopMostItemIndex?: VirtuosoProps<ReactElement, unknown>['initialTopMostItemIndex']
   keys: (string | number | bigint)[]
 }
 
 const virtuosoCalls = vi.hoisted(() => [] as VirtuosoCall[])
+const virtuosoLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
+const scrollAreaRefControl = vi.hoisted(() => ({ manual: false, ref: null as Ref<HTMLDivElement> | null }))
+
+vi.mock('@/components/ui/scroll-area', async () => {
+  const React = await import('react')
+  return {
+    ScrollArea: ({ children, ref }: { children?: ReactElement; ref?: React.Ref<HTMLDivElement> }) => {
+      scrollAreaRefControl.ref = ref ?? null
+      return React.createElement(
+        'div',
+        { 'data-testid': 'scroll-area' },
+        React.createElement('div', { ref: scrollAreaRefControl.manual ? undefined : ref }, children)
+      )
+    }
+  }
+})
 
 vi.mock('react-virtuoso', async () => {
   const React = await import('react')
   return {
-    Virtuoso: ({ data = [], computeItemKey, itemContent }: VirtuosoProps<ReactElement, unknown>) => {
+    Virtuoso: (props: VirtuosoProps<ReactElement, unknown>) => {
+      const {
+        alignToBottom,
+        customScrollParent,
+        data = [],
+        followOutput,
+        initialTopMostItemIndex,
+        computeItemKey,
+        itemContent
+      } = props
       if (!computeItemKey || !itemContent) throw new TypeError('Virtuoso list callbacks are required')
       const keys = data.map((item, index) => computeItemKey(index, item, undefined))
-      virtuosoCalls.push({ keys })
+      virtuosoCalls.push({ alignToBottom, customScrollParent, data, followOutput, initialTopMostItemIndex, keys })
+      useEffect(() => {
+        virtuosoLifecycle.mounts += 1
+        return () => {
+          virtuosoLifecycle.unmounts += 1
+        }
+      }, [])
       return React.createElement(
         'div',
-        null,
+        { 'data-testid': 'virtuoso' },
         data.map((item, index) =>
           React.createElement(React.Fragment, { key: keys[index] }, itemContent(index, item, undefined))
         )
@@ -72,7 +109,7 @@ const row = (message: GroupedMessage<DisplayMessage>, index: number, length: num
 
 const renderRows = (messages: readonly DisplayMessage[]) => {
   const grouped = groupAdjacentNotices(messages)
-  renderToStaticMarkup(
+  render(
     createElement(
       MessageList,
       null,
@@ -84,9 +121,86 @@ const renderRows = (messages: readonly DisplayMessage[]) => {
 
 beforeEach(() => {
   virtuosoCalls.length = 0
+  virtuosoLifecycle.mounts = 0
+  virtuosoLifecycle.unmounts = 0
+  scrollAreaRefControl.manual = false
+  scrollAreaRefControl.ref = null
 })
 
+afterEach(cleanup)
+
 describe('MessageList Virtuoso integration', () => {
+  it('waits for non-null content and the real viewport before the first Virtuoso render', () => {
+    const message = text('initial', 1)
+    const view = render(createElement(MessageList, null, null))
+
+    expect(virtuosoCalls).toHaveLength(0)
+    expect(view.getByTestId('scroll-area')).not.toBeNull()
+
+    view.rerender(createElement(MessageList, null, [row(message, 0, 1)]))
+
+    expect(virtuosoCalls).toHaveLength(1)
+    expect(virtuosoCalls[0]?.customScrollParent).toBeInstanceOf(HTMLElement)
+    expect(virtuosoCalls[0]?.data).toHaveLength(1)
+    expect(virtuosoCalls[0]?.initialTopMostItemIndex).toEqual({ index: 'LAST', align: 'end' })
+    expect(virtuosoCalls[0]?.alignToBottom).toBeUndefined()
+    expect(virtuosoLifecycle.mounts).toBe(1)
+  })
+
+  it('keeps one mounted list for empty history and later record updates', () => {
+    const view = render(createElement(MessageList, null, []))
+    const mountedList = view.getByTestId('virtuoso')
+
+    expect(virtuosoLifecycle.mounts).toBe(1)
+    expect(virtuosoCalls.at(-1)?.data).toHaveLength(0)
+
+    const message = text('later', 1)
+    view.rerender(createElement(MessageList, null, [row(message, 0, 1)]))
+
+    expect(view.getByTestId('virtuoso')).toBe(mountedList)
+    expect(virtuosoLifecycle).toEqual({ mounts: 1, unmounts: 0 })
+    expect(virtuosoCalls.at(-1)?.data).toHaveLength(1)
+  })
+
+  it('waits for a viewport and remounts only when that viewport resource is replaced', () => {
+    scrollAreaRefControl.manual = true
+    const message = text('initial', 1)
+    const view = render(createElement(MessageList, null, [row(message, 0, 1)]))
+
+    expect(virtuosoCalls).toHaveLength(0)
+    expect(view.queryByTestId('virtuoso')).toBeNull()
+    expect(typeof scrollAreaRefControl.ref).toBe('function')
+
+    const setViewport = scrollAreaRefControl.ref as (node: HTMLDivElement | null) => void
+    const firstViewport = document.createElement('div')
+    act(() => setViewport(firstViewport))
+
+    expect(view.getByTestId('virtuoso')).not.toBeNull()
+    expect(virtuosoCalls.at(-1)?.customScrollParent).toBe(firstViewport)
+    expect(virtuosoLifecycle).toEqual({ mounts: 1, unmounts: 0 })
+
+    act(() => setViewport(null))
+
+    expect(view.queryByTestId('virtuoso')).toBeNull()
+    expect(virtuosoLifecycle).toEqual({ mounts: 1, unmounts: 1 })
+
+    const replacementViewport = document.createElement('div')
+    act(() => setViewport(replacementViewport))
+
+    expect(view.getByTestId('virtuoso')).not.toBeNull()
+    expect(virtuosoCalls.at(-1)?.customScrollParent).toBe(replacementViewport)
+    expect(virtuosoLifecycle).toEqual({ mounts: 2, unmounts: 1 })
+  })
+
+  it('smooth-follows only when Virtuoso reports that the list was already at the bottom', () => {
+    renderRows([text('message', 1)])
+
+    const followOutput = virtuosoCalls.at(-1)?.followOutput
+    expect(typeof followOutput).toBe('function')
+    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
+    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
+  })
+
   it('keys text, singleton notice, and grouped notice rows from their stable projected identities', () => {
     expect(
       renderRows([notice('singleton', 1), text('separator', 2), notice('group-first', 3), notice('group-latest', 4)])
@@ -139,7 +253,7 @@ describe('MessageList Virtuoso integration', () => {
   })
 
   it('fails explicitly rather than substituting an array index for a missing row key', () => {
-    expect(() => renderToStaticMarkup(createElement(MessageList, null, [createElement('div')]))).toThrow(
+    expect(() => render(createElement(MessageList, null, [createElement('div')]))).toThrow(
       'MessageList items require a stable key'
     )
   })

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -4,7 +4,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Virtuoso } from 'react-virtuoso'
 
 export interface MessageListProps {
-  children?: ReactElement[]
+  children?: ReactElement[] | null
 }
 
 const itemKey = (_: number, item: ReactElement) => {
@@ -17,18 +17,20 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
 
   return (
     <ScrollArea ref={setScrollParentRef} className="dark:bg-slate-900">
-      <Virtuoso
-        defaultItemHeight={108}
-        increaseViewportBy={200}
-        overscan={200}
-        followOutput={(isAtBottom: boolean) => (isAtBottom ? 'smooth' : 'auto')}
-        initialTopMostItemIndex={{ index: 'LAST', align: 'end' }}
-        data={children}
-        customScrollParent={scrollParentRef!}
-        computeItemKey={itemKey}
-        skipAnimationFrameInResizeObserver
-        itemContent={(_, item) => item}
-      />
+      {children !== null && children !== undefined && scrollParentRef ? (
+        <Virtuoso
+          defaultItemHeight={108}
+          increaseViewportBy={200}
+          overscan={200}
+          followOutput={(isAtBottom: boolean) => (isAtBottom ? 'smooth' : false)}
+          initialTopMostItemIndex={{ index: 'LAST', align: 'end' }}
+          data={children}
+          customScrollParent={scrollParentRef}
+          computeItemKey={itemKey}
+          skipAnimationFrameInResizeObserver
+          itemContent={(_, item) => item}
+        />
+      ) : null}
     </ScrollArea>
   )
 }

--- a/src/app/content/views/main/index.tsx
+++ b/src/app/content/views/main/index.tsx
@@ -18,6 +18,7 @@ const Main: FC = () => {
   const userInfoDomain = useRemeshDomain(UserInfoDomain())
   const userInfo = useRemeshQuery(userInfoDomain.query.UserInfoQuery())
   const _messageList = useRemeshQuery(messageListDomain.query.ListQuery())
+  const messageListLoadFinished = useRemeshQuery(messageListDomain.query.LoadIsFinishedQuery())
 
   const messageList = useMemo(
     () =>
@@ -40,43 +41,45 @@ const Main: FC = () => {
 
   return (
     <MessageList>
-      {messageList.map((message, index) => {
-        const key = messageRowKey(message)
-        if (message.type === 'text') {
-          return (
-            <MessageItem
-              key={key}
-              data={message}
-              like={message.like}
-              hate={message.hate}
-              onToggleLike={() =>
-                send(chatRoomDomain.command.SendReactionCommand({ messageId: message.id, reaction: 'like' }))
-              }
-              onToggleHate={() =>
-                send(chatRoomDomain.command.SendReactionCommand({ messageId: message.id, reaction: 'hate' }))
-              }
-              className="animate-in fade-in-0 duration-300"
-            />
-          )
-        }
-        if (message.type === 'notice-group') {
-          return (
-            <NoticeGroup
-              key={key}
-              notices={message.notices}
-              first={index === 0}
-              last={index === messageList.length - 1}
-            />
-          )
-        }
-        return (
-          <NoticeItem
-            key={key}
-            data={message}
-            className={`${index === 0 ? 'pt-4' : ''} ${index === messageList.length - 1 ? 'pb-4' : ''}`}
-          />
-        )
-      })}
+      {messageListLoadFinished
+        ? messageList.map((message, index) => {
+            const key = messageRowKey(message)
+            if (message.type === 'text') {
+              return (
+                <MessageItem
+                  key={key}
+                  data={message}
+                  like={message.like}
+                  hate={message.hate}
+                  onToggleLike={() =>
+                    send(chatRoomDomain.command.SendReactionCommand({ messageId: message.id, reaction: 'like' }))
+                  }
+                  onToggleHate={() =>
+                    send(chatRoomDomain.command.SendReactionCommand({ messageId: message.id, reaction: 'hate' }))
+                  }
+                  className="animate-in fade-in-0 duration-300"
+                />
+              )
+            }
+            if (message.type === 'notice-group') {
+              return (
+                <NoticeGroup
+                  key={key}
+                  notices={message.notices}
+                  first={index === 0}
+                  last={index === messageList.length - 1}
+                />
+              )
+            }
+            return (
+              <NoticeItem
+                key={key}
+                data={message}
+                className={`${index === 0 ? 'pt-4' : ''} ${index === messageList.length - 1 ? 'pb-4' : ''}`}
+              />
+            )
+          })
+        : null}
     </MessageList>
   )
 }


### PR DESCRIPTION
Promote `develop@7d5a42e480c7f1cc7498981c1bd9c14ec6417cbb` to `master`.

Includes PR #105 (Virtuoso initial message-list settlement: mount gate on canonical readiness + real viewport, last-item/end initial location, bottom-only follow, pure presentational MessageList), Owner-accepted 2026-08-05.

Authorized by Owner (2026-08-05).