### PR TITLE
fix(runtime): wait ten seconds before rebuilding a closed Artico peer

### DIFF
--- a/src/runtime/ArticoRoomTransport.test.ts
+++ b/src/runtime/ArticoRoomTransport.test.ts
@@ -220,7 +220,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     stalePeer.emit('error', new Error('stale peer error'))
     stalePeer.emit('close')
     await rejoin
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     expect(errors).toEqual([])
@@ -242,7 +242,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     expect(errors.map((error) => error.message)).toEqual(['id-taken'])
 
     currentPeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     transport.dispose()
@@ -286,7 +286,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     currentPeer.emit('close')
 
     transport.leave('chat-v3')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(1)
     transport.dispose()
@@ -337,7 +337,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const chatRoom = fixture.rooms.get('chat-a')!
 
     chatPeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(3)
     const replacement = fixture.peers[2]
@@ -361,7 +361,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const worldRoom = fixture.rooms.get('world-v3')!
 
     transport.leave('chat-a')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     expect(transport.peerIdOf('chat-a')).toBe('')
@@ -379,7 +379,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const staleRoom = fixture.rooms.get('chat-a')!
 
     stalePeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(stalePeer.closed).toBe(true)
     expect(fixture.peers).toHaveLength(2)
@@ -397,7 +397,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const stalePeer = fixture.peers[0]
 
     stalePeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     stalePeer.emit('error', new Error('retired peer error'))
     expect(errors).toEqual([])
 

--- a/src/runtime/ArticoRoomTransport.ts
+++ b/src/runtime/ArticoRoomTransport.ts
@@ -120,7 +120,7 @@ export const createArticoRoomTransport = (): RoomTransport => {
       owner.restartTimer = globalThis.setTimeout(() => {
         owner.restartTimer = null
         startPeer(owner)
-      }, 5000)
+      }, 10000)
     })
   }
 


### PR DESCRIPTION
Child of the docs authority `2e5014f` (`docs/artico-close-restart-10s`). Changes only the outer auto-rebuild timer after a non-active Artico peer close from 5000 to 10000ms; the seven timer-boundary test advances are synced (FAIL-before: with the production change and 5000 advances, 4 tests failed; after the sync, 16/16 pass). No backoff/jitter/owner refactor; ClientLease/Coordinator health checks, grace, manual refresh, Socket.IO, protocol unchanged. Draft — no Ready/merge.