### PR TITLE
fix(runtime): wait ten seconds for both network auto-recovery timers

### DIFF
--- a/openspec/changes/set-runtime-recovery-cadence/design.md
+++ b/openspec/changes/set-runtime-recovery-cadence/design.md
@@ -1,38 +1,39 @@
 ## Context
 
-The two waits belong to separate existing recovery owners: close-driven Artico peer replacement and ClientLease page-registration retry. Each owner already provides its required triggers, single-flight behavior, fencing, cancellation, and settlement boundaries. See `proposal.md` for motivation and `specs/webrtc-runtime/spec.md` for the normative cadence.
+The two waits belong to separate existing recovery owners: close-driven Artico peer replacement and ClientLease page-registration retry. The current product decision increases only the outer close-driven Artico replacement wait from `5_000` to `10_000` milliseconds; ClientLease remains at `1_000` milliseconds. Each owner already provides its required triggers, single-flight behavior, fencing, cancellation, and settlement boundaries. See `proposal.md` for motivation and `specs/webrtc-runtime/spec.md` for the normative cadence.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Change only the literal wait owned by each existing recovery path.
-- Keep existing timer coverage aligned with the two resulting cadences.
+- Change only the close-driven Artico replacement literal from `5_000` to `10_000`.
+- Keep existing Artico timer coverage aligned with the resulting cadence.
+- Retain the separate ClientLease retry wait at `1_000` and every other recovery cadence unchanged.
 
 **Non-Goals:**
 
 - No recovery, lifecycle, ownership, or control-flow changes.
-- No shared timing abstraction, new test case, dependency, or public surface.
+- No Socket.IO reconnect configuration, backoff, jitter, reconnect-owner consolidation, shared timing abstraction, new test case, dependency, or public surface.
 
 ## Decisions
 
 ### Keep the waits at their existing owners
 
-Change the close-restart literal in the Artico transport owner to `5_000` and the default registration-retry literal in ClientLease to `1_000`. These values remain separate because they govern unrelated lifecycle transitions. A shared constant would create coupling without removing behavior or concepts.
+Change the close-restart literal in the Artico transport owner to `10_000` and retain the default registration-retry literal in ClientLease at `1_000`. These values remain separate because they govern unrelated lifecycle transitions. A shared constant would create coupling without removing behavior or concepts.
 
 Alternative considered: introduce named or shared configuration. Rejected because the requested values are fixed, each currently has one owner, and new structure would exceed the authorized numeric-only change.
 
-### Synchronize only existing timer expectations
+### Synchronize only existing Artico timer expectations
 
-Mechanically update existing elapsed-time expectations whose value directly includes either changed wait. Do not add test cases or restructure timer setup. Existing tests already exercise the affected paths; this change only updates their expected cadence.
+Mechanically update existing elapsed-time expectations whose value directly includes the changed Artico wait. An existing close-recovery control must prove that no replacement exists before `10_000ms` and exactly one exists when the boundary is reached. Do not add test cases or restructure timer setup. Existing tests already exercise immediate fresh-demand repair, stale callback fencing, cancellation, disposal, and single replacement; this change only aligns those controls with the new cadence. ClientLease expectations remain unchanged.
 
 Alternative considered: add dedicated cadence suites. Rejected because that would expand test structure beyond the authorized change.
 
 ### Preserve every surrounding boundary
 
-Do not change the immediate fresh-demand repair path, timer triggers, per-request deadline, total recovery budget, watchdog cadence, generation fencing, readiness behavior, or terminal settlement. The two literals must remain inputs to the existing control flow rather than new recovery policy.
+Do not change the immediate fresh-demand repair path, timer triggers, AppButton/manual reconnect behavior, Socket.IO's internal reconnect behavior, ClientLease or Coordinator health checks, Background heartbeat timeout, presence/grace/release timing, per-request deadline, total recovery budget, generation fencing, readiness behavior, or terminal settlement. The Artico literal remains an input to the existing control flow rather than a new recovery policy.
 
 ## Risks / Trade-offs
 
-- **Derived timer expectations can retain the prior elapsed total** -> Inspect and update only existing expectations directly composed from either changed wait.
+- **Derived timer expectations can retain the prior elapsed total** -> Inspect and update only existing expectations directly composed from the Artico close-restart wait.
 - **A shared constant could falsely imply one policy** -> Keep the values local to their independent owners.

--- a/openspec/changes/set-runtime-recovery-cadence/design.md
+++ b/openspec/changes/set-runtime-recovery-cadence/design.md
@@ -25,7 +25,7 @@ Alternative considered: introduce named or shared configuration. Rejected becaus
 
 ### Synchronize only existing network-retry timer expectations
 
-Mechanically update existing elapsed-time expectations whose value directly includes either changed network-retry wait. Existing close-recovery, Domain recovery, and World recovery controls must prove that no replacement or retry begins before `10_000ms` and exactly one begins when the boundary is reached. Do not add test cases or restructure timer setup. Existing tests already exercise immediate fresh-demand repair, stale callback fencing, cancellation, disposal, single replacement, failed initial joins, and failed active-room recovery; this change only aligns those controls with the new cadence. ClientLease expectations remain unchanged.
+Mechanically replace only the existing elapsed-time expectations whose value directly includes either changed network-retry wait from `5_000` to `10_000`. Do not add a pre-boundary negative assertion, an extra exactly-once assertion, a test case, or a test abstraction, and do not restructure timer setup. Existing tests already exercise immediate fresh-demand repair, stale callback fencing, cancellation, disposal, single replacement, failed initial joins, and failed active-room recovery; this change only aligns their existing boundary values with the new cadence. ClientLease expectations remain unchanged.
 
 Alternative considered: add dedicated cadence suites. Rejected because that would expand test structure beyond the authorized change.
 

--- a/openspec/changes/set-runtime-recovery-cadence/design.md
+++ b/openspec/changes/set-runtime-recovery-cadence/design.md
@@ -1,14 +1,14 @@
 ## Context
 
-The two waits belong to separate existing recovery owners: close-driven Artico peer replacement and ClientLease page-registration retry. The current product decision increases only the outer close-driven Artico replacement wait from `5_000` to `10_000` milliseconds; ClientLease remains at `1_000` milliseconds. Each owner already provides its required triggers, single-flight behavior, fencing, cancellation, and settlement boundaries. See `proposal.md` for motivation and `specs/webrtc-runtime/spec.md` for the normative cadence.
+The recovery waits belong to separate existing owners: close-driven Artico peer replacement, Connection's Domain/World recovery retry, and ClientLease page-registration retry. The current product decision increases the two waits that initiate signaling or room-join recovery from `5_000` to `10_000` milliseconds; ClientLease remains at `1_000` milliseconds. Each owner already provides its required triggers, single-flight behavior, fencing, cancellation, and settlement boundaries. See `proposal.md` for motivation and `specs/webrtc-runtime/spec.md` for the normative cadence.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Change only the close-driven Artico replacement literal from `5_000` to `10_000`.
-- Keep existing Artico timer coverage aligned with the resulting cadence.
-- Retain the separate ClientLease retry wait at `1_000` and every other recovery cadence unchanged.
+- Change only the close-driven Artico replacement and Connection Domain/World recovery literals from `5_000` to `10_000`.
+- Keep existing Artico and Connection timer coverage aligned with the resulting cadence.
+- Retain the separate ClientLease retry wait at `1_000` and every non-network-retry cadence unchanged.
 
 **Non-Goals:**
 
@@ -19,21 +19,21 @@ The two waits belong to separate existing recovery owners: close-driven Artico p
 
 ### Keep the waits at their existing owners
 
-Change the close-restart literal in the Artico transport owner to `10_000` and retain the default registration-retry literal in ClientLease at `1_000`. These values remain separate because they govern unrelated lifecycle transitions. A shared constant would create coupling without removing behavior or concepts.
+Change the close-restart literal in the Artico transport owner and the Domain/World recovery-retry literal in Connection to `10_000`; retain the default registration-retry literal in ClientLease at `1_000`. These values remain local because the two network paths have independent owners and ClientLease governs a separate control-plane lifecycle. A shared constant would create coupling without removing behavior or concepts.
 
 Alternative considered: introduce named or shared configuration. Rejected because the requested values are fixed, each currently has one owner, and new structure would exceed the authorized numeric-only change.
 
-### Synchronize only existing Artico timer expectations
+### Synchronize only existing network-retry timer expectations
 
-Mechanically update existing elapsed-time expectations whose value directly includes the changed Artico wait. An existing close-recovery control must prove that no replacement exists before `10_000ms` and exactly one exists when the boundary is reached. Do not add test cases or restructure timer setup. Existing tests already exercise immediate fresh-demand repair, stale callback fencing, cancellation, disposal, and single replacement; this change only aligns those controls with the new cadence. ClientLease expectations remain unchanged.
+Mechanically update existing elapsed-time expectations whose value directly includes either changed network-retry wait. Existing close-recovery, Domain recovery, and World recovery controls must prove that no replacement or retry begins before `10_000ms` and exactly one begins when the boundary is reached. Do not add test cases or restructure timer setup. Existing tests already exercise immediate fresh-demand repair, stale callback fencing, cancellation, disposal, single replacement, failed initial joins, and failed active-room recovery; this change only aligns those controls with the new cadence. ClientLease expectations remain unchanged.
 
 Alternative considered: add dedicated cadence suites. Rejected because that would expand test structure beyond the authorized change.
 
 ### Preserve every surrounding boundary
 
-Do not change the immediate fresh-demand repair path, timer triggers, AppButton/manual reconnect behavior, Socket.IO's internal reconnect behavior, ClientLease or Coordinator health checks, Background heartbeat timeout, presence/grace/release timing, per-request deadline, total recovery budget, generation fencing, readiness behavior, or terminal settlement. The Artico literal remains an input to the existing control flow rather than a new recovery policy.
+Do not change the immediate fresh-demand repair path, timer triggers, AppButton/manual reconnect behavior, Socket.IO's internal reconnect behavior, ClientLease or Coordinator health checks, Background heartbeat timeout, presence/grace/release timing, per-request deadline, total recovery budget, generation fencing, readiness behavior, or terminal settlement. The two changed literals remain inputs to existing control flow rather than a new recovery policy.
 
 ## Risks / Trade-offs
 
-- **Derived timer expectations can retain the prior elapsed total** -> Inspect and update only existing expectations directly composed from the Artico close-restart wait.
+- **Derived timer expectations can retain the prior elapsed total** -> Inspect and update only existing expectations directly composed from the Artico close-restart or Connection Domain/World recovery wait.
 - **A shared constant could falsely imply one policy** -> Keep the values local to their independent owners.

--- a/openspec/changes/set-runtime-recovery-cadence/proposal.md
+++ b/openspec/changes/set-runtime-recovery-cadence/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-Transport and control-plane recovery need deliberate fixed waits so repeated work does not begin too quickly while the preceding peer or Runtime-host transition is settling. The waits must change without altering recovery ownership, triggers, deadlines, budgets, or user-facing behavior.
+Transport and control-plane recovery need deliberate fixed waits so repeated work does not begin too quickly while the preceding peer or Runtime-host transition is settling. The outer close-driven Artico replacement wait is increased from five to ten seconds without altering recovery ownership, triggers, deadlines, budgets, or user-facing behavior; the separate ClientLease retry wait remains unchanged.
 
 ## What Changes
 
-- Set the close-driven Artico peer replacement wait to exactly 5,000ms.
-- Set the default ClientLease wait between failed current `registerPage()` attempts to exactly 1,000ms.
-- Preserve immediate disconnected-peer repair on fresh room demand, the existing ClientLease per-request deadline and overall recovery budget, every other cadence, and all current ownership, fencing, settlement, and feedback behavior.
-- Implement only the two numeric substitutions and mechanically synchronize existing timer expectations made stale by them; add no logic, structure, abstraction, or new test case.
+- Set the close-driven Artico peer replacement wait to exactly 10,000ms instead of 5,000ms.
+- Retain the default ClientLease wait between failed current `registerPage()` attempts at exactly 1,000ms.
+- Preserve immediate disconnected-peer repair on fresh room demand, Socket.IO internal reconnect, AppButton/manual reconnect, ClientLease and Coordinator 5-second health checks, the Background heartbeat timeout, presence/grace/release timing, the existing ClientLease per-request deadline and overall recovery budget, every other cadence, and all current ownership, fencing, settlement, and feedback behavior.
+- Implement only the Artico numeric substitution and mechanically synchronize existing Artico timer expectations made stale by it; add no logic, structure, abstraction, or new test case.
 
 ## Capabilities
 
@@ -17,10 +17,10 @@ None.
 
 ### Modified Capabilities
 
-- `webrtc-runtime`: Fix the close-driven Artico replacement wait and ClientLease registration-retry wait while preserving every surrounding recovery boundary.
+- `webrtc-runtime`: Set the close-driven Artico replacement wait to ten seconds while retaining the separate ClientLease registration-retry wait and every surrounding recovery boundary.
 
 ## Impact
 
-- Affected implementation: the existing Artico close-restart timer and ClientLease default registration-retry interval.
-- Affected tests: only existing timer expectations that directly encode either changed value.
-- Unchanged: recovery triggers and ownership, immediate disconnected-peer repair, peer identity, desired-room handling, ClientLease request deadlines and total budget, watchdog cadence, readiness/feedback, protocol, persistence, dependencies, permissions, public APIs, and browser-specific behavior.
+- Affected implementation: only the existing Artico close-restart timer.
+- Affected tests: only existing Artico timer expectations that directly encode the changed value.
+- Unchanged: Socket.IO internal reconnect, AppButton/manual reconnect, recovery triggers and ownership, immediate disconnected-peer repair, peer identity, desired-room handling, ClientLease registration retry, request deadlines and total budget, ClientLease and Coordinator health checks, Background heartbeat timeout, presence/grace/release timing, readiness/feedback, protocol, persistence, identity, wire behavior, dependencies, permissions, public APIs, and browser-specific behavior.

--- a/openspec/changes/set-runtime-recovery-cadence/proposal.md
+++ b/openspec/changes/set-runtime-recovery-cadence/proposal.md
@@ -1,13 +1,14 @@
 ## Why
 
-Transport and control-plane recovery need deliberate fixed waits so repeated work does not begin too quickly while the preceding peer or Runtime-host transition is settling. The outer close-driven Artico replacement wait is increased from five to ten seconds without altering recovery ownership, triggers, deadlines, budgets, or user-facing behavior; the separate ClientLease retry wait remains unchanged.
+Transport and control-plane recovery need deliberate fixed waits so repeated work does not begin too quickly while the preceding peer or room transition is settling. The close-driven Artico replacement wait and the Domain/World failed-recovery retry wait are increased from five to ten seconds without altering recovery ownership, triggers, deadlines, budgets, or user-facing behavior; the separate ClientLease retry wait remains unchanged.
 
 ## What Changes
 
 - Set the close-driven Artico peer replacement wait to exactly 10,000ms instead of 5,000ms.
+- Set the Connection Domain/World automatic recovery retry wait to exactly 10,000ms instead of 5,000ms.
 - Retain the default ClientLease wait between failed current `registerPage()` attempts at exactly 1,000ms.
 - Preserve immediate disconnected-peer repair on fresh room demand, Socket.IO internal reconnect, AppButton/manual reconnect, ClientLease and Coordinator 5-second health checks, the Background heartbeat timeout, presence/grace/release timing, the existing ClientLease per-request deadline and overall recovery budget, every other cadence, and all current ownership, fencing, settlement, and feedback behavior.
-- Implement only the Artico numeric substitution and mechanically synchronize existing Artico timer expectations made stale by it; add no logic, structure, abstraction, or new test case.
+- Implement only the two network-retry numeric substitutions and mechanically synchronize existing timer expectations made stale by them; add no logic, structure, abstraction, or new test case.
 
 ## Capabilities
 
@@ -17,10 +18,10 @@ None.
 
 ### Modified Capabilities
 
-- `webrtc-runtime`: Set the close-driven Artico replacement wait to ten seconds while retaining the separate ClientLease registration-retry wait and every surrounding recovery boundary.
+- `webrtc-runtime`: Set close-driven Artico replacement and Connection Domain/World failed-recovery retry to ten seconds while retaining the separate ClientLease registration-retry wait and every surrounding boundary.
 
 ## Impact
 
-- Affected implementation: only the existing Artico close-restart timer.
-- Affected tests: only existing Artico timer expectations that directly encode the changed value.
+- Affected implementation: only the existing Artico close-restart timer and Connection Domain/World recovery-retry interval.
+- Affected tests: only existing Artico and Connection timer expectations that directly encode either changed value.
 - Unchanged: Socket.IO internal reconnect, AppButton/manual reconnect, recovery triggers and ownership, immediate disconnected-peer repair, peer identity, desired-room handling, ClientLease registration retry, request deadlines and total budget, ClientLease and Coordinator health checks, Background heartbeat timeout, presence/grace/release timing, readiness/feedback, protocol, persistence, identity, wire behavior, dependencies, permissions, public APIs, and browser-specific behavior.

--- a/openspec/changes/set-runtime-recovery-cadence/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/set-runtime-recovery-cadence/specs/webrtc-runtime/spec.md
@@ -2,21 +2,29 @@
 
 ### Requirement: Runtime recovery waits are fixed and isolated
 
-Close-driven Artico peer replacement SHALL wait exactly 5,000ms before replacing the current peer. Fresh room demand that encounters a retained disconnected peer SHALL retain its existing immediate repair path and MAY preempt the pending close-driven wait through the same single restart owner. The wait SHALL NOT change room demand, peer identity, generation fencing, callback settlement, leave, or disposal behavior.
+Close-driven Artico peer replacement SHALL wait exactly 10,000ms before replacing the current peer. Fresh room demand that encounters a retained disconnected peer SHALL retain its existing immediate repair path and MAY preempt the pending close-driven wait through the same single restart owner. The wait SHALL NOT change room demand, peer identity, generation fencing, callback settlement, leave, or disposal behavior. Duplicate or stale close callbacks SHALL NOT schedule an additional replacement, and leave or disposal SHALL continue to cancel pending restart work.
 
 After a failed current page-registration attempt, ClientLease SHALL wait exactly 1,000ms before its next eligible registration attempt. The retry wait SHALL remain inside the current single-flight recovery generation and its existing 15,000ms overall budget. The 5,000ms per-request deadline, 5,000ms watchdog cadence, retry triggers, stale-generation fencing, readiness settlement, and every other recovery interval SHALL remain unchanged.
 
-#### Scenario: Close-driven peer replacement waits five seconds
+This outer Artico wait SHALL NOT alter Socket.IO internal reconnect, AppButton/manual reconnect, ClientLease or Coordinator health checks, the Background heartbeat timeout, presence/grace/release timing, protocol, API, persistence, identity, or wire behavior. It SHALL introduce no backoff, jitter, reconnect-owner refactor, compatibility behavior, or unrelated timeout change.
+
+#### Scenario: Close-driven peer replacement waits ten seconds
 
 - **GIVEN** the current Artico peer closes and its close-driven replacement remains the active restart owner
 - **WHEN** no fresh room demand preempts that wait
-- **THEN** replacement SHALL begin after exactly 5,000ms and SHALL NOT begin earlier
+- **THEN** no automatic replacement SHALL exist before 10,000ms, and exactly one replacement SHALL begin when 10,000ms is reached
 
 #### Scenario: Fresh demand retains immediate disconnected-peer repair
 
 - **GIVEN** a close-driven replacement wait is pending for a retained disconnected peer
 - **WHEN** fresh room demand requires that peer
 - **THEN** the existing immediate repair path SHALL enter the same restart owner without waiting for the close-driven timer, and the delayed work SHALL NOT create a duplicate replacement
+
+#### Scenario: Close recovery remains cancellable and generation-fenced
+
+- **GIVEN** close-driven replacement work is pending for the current peer generation
+- **WHEN** matching room demand leaves, the transport is disposed, or duplicate or stale close work arrives
+- **THEN** leave or disposal SHALL cancel its owned pending restart, and duplicate or stale work SHALL NOT create an additional replacement
 
 #### Scenario: Failed registration waits one second before retry
 

--- a/openspec/changes/set-runtime-recovery-cadence/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/set-runtime-recovery-cadence/specs/webrtc-runtime/spec.md
@@ -4,9 +4,11 @@
 
 Close-driven Artico peer replacement SHALL wait exactly 10,000ms before replacing the current peer. Fresh room demand that encounters a retained disconnected peer SHALL retain its existing immediate repair path and MAY preempt the pending close-driven wait through the same single restart owner. The wait SHALL NOT change room demand, peer identity, generation fencing, callback settlement, leave, or disposal behavior. Duplicate or stale close callbacks SHALL NOT schedule an additional replacement, and leave or disposal SHALL continue to cancel pending restart work.
 
-After a failed current page-registration attempt, ClientLease SHALL wait exactly 1,000ms before its next eligible registration attempt. The retry wait SHALL remain inside the current single-flight recovery generation and its existing 15,000ms overall budget. The 5,000ms per-request deadline, 5,000ms watchdog cadence, retry triggers, stale-generation fencing, readiness settlement, and every other recovery interval SHALL remain unchanged.
+After a current Domain or World connection attempt fails and its existing automatic recovery owner remains eligible, Connection SHALL wait exactly 10,000ms before retrying that recovery. The wait SHALL apply equally to failed initial and active-room recovery for Chat and World. It SHALL NOT change which failures are eligible, preserve or recreate input, create a retry after cancellation/release/supersession, or alter attempt, host-generation, request, readiness, failure, or terminal-settlement authority.
 
-This outer Artico wait SHALL NOT alter Socket.IO internal reconnect, AppButton/manual reconnect, ClientLease or Coordinator health checks, the Background heartbeat timeout, presence/grace/release timing, protocol, API, persistence, identity, or wire behavior. It SHALL introduce no backoff, jitter, reconnect-owner refactor, compatibility behavior, or unrelated timeout change.
+After a failed current page-registration attempt, ClientLease SHALL wait exactly 1,000ms before its next eligible registration attempt. The retry wait SHALL remain inside the current single-flight recovery generation and its existing 15,000ms overall budget. The 5,000ms per-request deadline, 5,000ms watchdog cadence, retry triggers, stale-generation fencing, readiness settlement, and every other ClientLease interval SHALL remain unchanged.
+
+These two network-retry waits SHALL NOT alter Socket.IO internal reconnect, AppButton/manual reconnect, ClientLease or Coordinator health checks, the Background heartbeat timeout, presence/grace/release timing, protocol, API, persistence, identity, or wire behavior. They SHALL introduce no backoff, jitter, reconnect-owner refactor, compatibility behavior, or unrelated timeout change.
 
 #### Scenario: Close-driven peer replacement waits ten seconds
 
@@ -25,6 +27,18 @@ This outer Artico wait SHALL NOT alter Socket.IO internal reconnect, AppButton/m
 - **GIVEN** close-driven replacement work is pending for the current peer generation
 - **WHEN** matching room demand leaves, the transport is disposed, or duplicate or stale close work arrives
 - **THEN** leave or disposal SHALL cancel its owned pending restart, and duplicate or stale work SHALL NOT create an additional replacement
+
+#### Scenario: Failed Domain and World recovery waits ten seconds
+
+- **GIVEN** a current failed initial or active-room recovery retains an eligible Domain or World automatic retry owner
+- **WHEN** that owner remains current and is not cancelled, released, or superseded
+- **THEN** no retry SHALL begin before 10,000ms, and exactly one matching retry SHALL begin when 10,000ms is reached
+
+#### Scenario: Connection retry preserves existing authority
+
+- **GIVEN** a Domain or World recovery retry is delayed
+- **WHEN** its attempt, request, domain, host generation, or lifecycle owner becomes stale or ineligible
+- **THEN** the delayed work SHALL not join, retry, publish readiness, report a new failure, or settle current work
 
 #### Scenario: Failed registration waits one second before retry
 

--- a/openspec/changes/set-runtime-recovery-cadence/tasks.md
+++ b/openspec/changes/set-runtime-recovery-cadence/tasks.md
@@ -10,9 +10,9 @@
 
 ## 3. Mechanical Test Synchronization
 
-- [ ] 3.1 Update only existing Artico timer expectations made stale by the `10_000` wait, including a pre-boundary assertion in an existing close-recovery control; add no test case or test abstraction.
+- [ ] 3.1 Mechanically update only existing Artico timer values made stale by the `10_000` wait; add no pre-boundary or exactly-once assertion, test case, test abstraction, or setup restructuring.
 - [x] 3.2 Update only existing ClientLease timer expectations made stale by the `1_000` wait; add no test case or test abstraction.
-- [ ] 3.3 Update only existing failed initial/active Chat and World recovery timer expectations made stale by the `10_000` wait, including pre-boundary assertions; add no test case or test abstraction.
+- [ ] 3.3 Mechanically update only existing failed initial/active Chat and World recovery timer values made stale by the `10_000` wait; add no pre-boundary or exactly-once assertion, test case, test abstraction, or setup restructuring.
 
 ## 4. Verification And Delivery
 

--- a/openspec/changes/set-runtime-recovery-cadence/tasks.md
+++ b/openspec/changes/set-runtime-recovery-cadence/tasks.md
@@ -4,15 +4,15 @@
 
 ## 2. Numeric Substitutions
 
-- [x] 2.1 Set the existing close-driven Artico peer replacement wait literal to `5_000` without changing its surrounding logic or structure.
+- [ ] 2.1 Set the existing close-driven Artico peer replacement wait literal to `10_000` without changing its surrounding logic or structure.
 - [x] 2.2 Set the existing ClientLease default page-registration retry wait literal to `1_000` without changing its surrounding logic or structure.
 
 ## 3. Mechanical Test Synchronization
 
-- [x] 3.1 Update only existing Artico timer expectations made stale by the `5_000` wait; add no test case or test abstraction.
+- [ ] 3.1 Update only existing Artico timer expectations made stale by the `10_000` wait, including a pre-boundary assertion in an existing close-recovery control; add no test case or test abstraction.
 - [x] 3.2 Update only existing ClientLease timer expectations made stale by the `1_000` wait; add no test case or test abstraction.
 
 ## 4. Verification And Delivery
 
-- [x] 4.1 Run the affected existing timer suites and repository delivery checks on the implementation exact.
-- [x] 4.2 Confirm review and CI pass on an exact whose source diff contains only the two numeric substitutions and mechanical expectation updates.
+- [ ] 4.1 Run the affected existing timer suites and repository delivery checks on the implementation exact.
+- [ ] 4.2 Confirm review and CI pass on an exact whose implementation diff contains only the Artico numeric substitution and mechanical Artico expectation updates.

--- a/openspec/changes/set-runtime-recovery-cadence/tasks.md
+++ b/openspec/changes/set-runtime-recovery-cadence/tasks.md
@@ -1,18 +1,20 @@
 ## 1. Product Contract
 
-- [x] 1.1 Record the two exact waits and every unchanged recovery boundary in the delta spec and design.
+- [x] 1.1 Record the three exact waits and every unchanged recovery boundary in the delta spec and design.
 
 ## 2. Numeric Substitutions
 
 - [ ] 2.1 Set the existing close-driven Artico peer replacement wait literal to `10_000` without changing its surrounding logic or structure.
 - [x] 2.2 Set the existing ClientLease default page-registration retry wait literal to `1_000` without changing its surrounding logic or structure.
+- [ ] 2.3 Set the existing Connection Domain/World automatic recovery retry literal to `10_000` without changing its surrounding logic or structure.
 
 ## 3. Mechanical Test Synchronization
 
 - [ ] 3.1 Update only existing Artico timer expectations made stale by the `10_000` wait, including a pre-boundary assertion in an existing close-recovery control; add no test case or test abstraction.
 - [x] 3.2 Update only existing ClientLease timer expectations made stale by the `1_000` wait; add no test case or test abstraction.
+- [ ] 3.3 Update only existing failed initial/active Chat and World recovery timer expectations made stale by the `10_000` wait, including pre-boundary assertions; add no test case or test abstraction.
 
 ## 4. Verification And Delivery
 
 - [ ] 4.1 Run the affected existing timer suites and repository delivery checks on the implementation exact.
-- [ ] 4.2 Confirm review and CI pass on an exact whose implementation diff contains only the Artico numeric substitution and mechanical Artico expectation updates.
+- [ ] 4.2 Confirm review and CI pass on an exact whose implementation diff contains only the Artico and Connection numeric substitutions plus their mechanical timer expectation updates.

--- a/src/domain/runtime/Connection.ts
+++ b/src/domain/runtime/Connection.ts
@@ -64,7 +64,7 @@ export interface RuntimeFailure {
 }
 
 const PHYSICAL_ROOM_JOIN_TIMEOUT_MS = 10000
-export const ROOM_RECOVERY_RETRY_INTERVAL_MS = 5000
+export const ROOM_RECOVERY_RETRY_INTERVAL_MS = 10000
 const replaceBy = <T>(items: T[], predicate: (item: T) => boolean, next: T): T[] =>
   items.some(predicate) ? items.map((item) => (predicate(item) ? next : item)) : [...items, next]
 const worldJoinRequestId = (requestId: string) => `connection:world:${requestId}`

--- a/src/runtime/ArticoRoomTransport.test.ts
+++ b/src/runtime/ArticoRoomTransport.test.ts
@@ -220,7 +220,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     stalePeer.emit('error', new Error('stale peer error'))
     stalePeer.emit('close')
     await rejoin
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     expect(errors).toEqual([])
@@ -242,7 +242,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     expect(errors.map((error) => error.message)).toEqual(['id-taken'])
 
     currentPeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     transport.dispose()
@@ -286,7 +286,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     currentPeer.emit('close')
 
     transport.leave('chat-v3')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(1)
     transport.dispose()
@@ -337,7 +337,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const chatRoom = fixture.rooms.get('chat-a')!
 
     chatPeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(3)
     const replacement = fixture.peers[2]
@@ -361,7 +361,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const worldRoom = fixture.rooms.get('world-v3')!
 
     transport.leave('chat-a')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(fixture.peers).toHaveLength(2)
     expect(transport.peerIdOf('chat-a')).toBe('')
@@ -379,7 +379,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const staleRoom = fixture.rooms.get('chat-a')!
 
     stalePeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
 
     expect(stalePeer.closed).toBe(true)
     expect(fixture.peers).toHaveLength(2)
@@ -397,7 +397,7 @@ describe('ArticoRoomTransport per-target isolation', () => {
     const stalePeer = fixture.peers[0]
 
     stalePeer.emit('close')
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     stalePeer.emit('error', new Error('retired peer error'))
     expect(errors).toEqual([])
 

--- a/src/runtime/ArticoRoomTransport.ts
+++ b/src/runtime/ArticoRoomTransport.ts
@@ -120,7 +120,7 @@ export const createArticoRoomTransport = (): RoomTransport => {
       owner.restartTimer = globalThis.setTimeout(() => {
         owner.restartTimer = null
         startPeer(owner)
-      }, 5000)
+      }, 10000)
     })
   }
 

--- a/src/runtime/Server.test.ts
+++ b/src/runtime/Server.test.ts
@@ -1885,7 +1885,7 @@ describe('RuntimeServer lifecycle', () => {
     await vi.waitFor(() => expect(failures).toEqual([`Room "${roomId}" join failed`]))
     expect(fake.joined.has(roomId)).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     await settle()
 
     expect(fake.joined.has(roomId)).toBe(true)
@@ -1905,7 +1905,7 @@ describe('RuntimeServer lifecycle', () => {
     await vi.waitFor(() => expect(failures).toEqual([`Room "${worldRoomId}" join failed`]))
     expect((await server.getSnapshot()).world.joined).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     await settle()
 
     expect((await server.getSnapshot()).world.joined).toBe(true)
@@ -1923,7 +1923,7 @@ describe('RuntimeServer lifecycle', () => {
     await expect(server.joinChatRoom({ domain: DOMAIN, user: USER, site: SITE })).rejects.toThrow()
     const joinsBefore = fake.joinCalls.filter((roomId) => roomId === chatRoomId).length
 
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     await settle()
 
     const joinsAfter = fake.joinCalls.filter((roomId) => roomId === chatRoomId).length
@@ -1947,7 +1947,7 @@ describe('RuntimeServer lifecycle', () => {
     await expect(server.joinChatRoom({ domain: DOMAIN, user: USER, site: SITE })).rejects.toThrow()
     const worldJoinsBefore = fake.joinCalls.filter((roomId) => roomId === worldRoomId).length
 
-    await vi.advanceTimersByTimeAsync(5000)
+    await vi.advanceTimersByTimeAsync(10000)
     await settle()
 
     const worldJoinsAfter = fake.joinCalls.filter((roomId) => roomId === worldRoomId).length


### PR DESCRIPTION
Child of the replacement docs authority `4289c708` (`docs/artico-close-restart-10s`, sole parent `2e5014f`). Two 5s→10s changes: Artico peer-close outer rebuild (ArticoRoomTransport) and Connection.ROOM_RECOVERY_RETRY_INTERVAL_MS (Domain/World failure recovery). 7 Artico + 4 Server timer controls synced to the 10,000ms boundary (FAIL-before: with production-only changes the old 5000 advances fail). Grace/health/heartbeat/Socket.IO/manual/other timeouts unchanged. Draft — no Ready/merge.