### PR TITLE
fix(runtime): pin the Artico signaling endpoint to the owned server

### DIFF
--- a/openspec/changes/set-artico-signaling-endpoint/design.md
+++ b/openspec/changes/set-artico-signaling-endpoint/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`createArticoRoomTransport()` owns one Artico peer generation for World and one for each active Chat domain. Its `startPeer()` currently calls `new Artico({ id: owner.peerId })`. In pinned `@rtco/client@0.3.6`, omitting `signaling` creates `SocketSignaling` with `https://0.artico.dev:443`, WebSocket-only Socket.IO transport, the default `/socket.io` path, and query `{ id }`.
+
+Read-only validation on 2026-08-13 found `web-chat.io` resolving to an IPv4 address and presenting a valid browser-trusted certificate for that hostname. The exact pinned `SocketSignaling` client reached its `ready` state at `wss://web-chat.io` and the service returned the requested id. A separate Chromium WebSocket upgrade to the default Socket.IO path also opened successfully. An HTTPS root `404` is not a signaling failure because the signaling contract lives at the Socket.IO WebSocket endpoint; a polling request is likewise not authoritative because the pinned client uses WebSocket only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the owned endpoint an explicit source-level invariant for every current and replacement Artico peer.
+- Keep signaling identity equal to the room owner's current physical `peerId`.
+- Ship one endpoint in development and production and fail visibly without fallback.
+- Preserve the pinned Socket.IO signaling protocol and every existing Runtime owner.
+- Keep automated tests deterministic and network-free without adding production configurability.
+
+**Non-Goals:**
+
+- No endpoint pool, failover, environment variable, build-mode branch, user setting, public configuration, or compatibility alias.
+- No DNS, TLS certificate, reverse-proxy, Socket.IO server, container, deployment, or production modification.
+- No Socket.IO path, transport, reconnection policy, Engine.IO version, query shape, authentication, or server protocol change.
+- No Artico/Socket.IO dependency upgrade, custom signaling implementation, WebRTC/STUN/TURN change, peer-owner refactor, recovery-timer change, protocol/API/schema/persistence change, or new browser permission.
+
+## Decisions
+
+### 1. The Runtime explicitly composes the built-in signaling client
+
+At the existing Artico peer-creation boundary, create `SocketSignaling` with the exact URL `wss://web-chat.io` and the owner's current physical `peerId`, then pass that signaling instance into the new Artico peer. The Artico peer and signaling client must expose the same id for initial creation and every generation replacement.
+
+The endpoint remains a fixed source value at this one composition boundary. A local constant may name it, but no configuration abstraction or public injection surface is introduced.
+
+Alternative rejected: rely on Artico's package default. It keeps production behavior controlled by an upstream implicit value and can silently return WebChat to `0.artico.dev`.
+
+Alternative rejected: add an environment variable with the vendor default as fallback. That creates different development/production behavior and makes a missing build setting silently select the wrong service.
+
+### 2. Development and production ship the same sole endpoint
+
+Every actual browser build, including local development builds, uses `wss://web-chat.io`. There is no localhost signaling server, secondary endpoint, endpoint list, or build-time/runtime selection. This makes the built artifact's connection target auditable from source and prevents environment drift.
+
+Tests may replace `@rtco/client` or the existing private provider boundary with test-owned fakes so they can inspect composition without network access. That substitution exists only in test code; production code does not inspect test mode, accept a test URL, or fall back when the fake is absent.
+
+### 3. Preserve the pinned Socket.IO wire behavior
+
+Use `SocketSignaling` without adding a path or transport adapter. The pinned client therefore retains its default `/socket.io` path, WebSocket-only transport, current Engine.IO/Socket.IO handshake, and query `{ id: owner.peerId }`. The URL contains no room, peer, token, or alternate path. Existing room join and signal events remain unchanged after readiness.
+
+Normal browser TLS hostname and trust validation remains mandatory. Source code must not bypass certificate validation or downgrade to insecure HTTP/WS. DNS, certificate renewal, reverse-proxy routing, and server availability are operational prerequisites outside this source-only change.
+
+Alternative rejected: append `/socket.io` to the configured URL or implement a raw WebSocket client. The former risks changing Socket.IO URL/path interpretation; the latter creates a new signaling protocol outside the requested endpoint substitution.
+
+### 4. Endpoint failure is fail-closed
+
+Connection errors and disconnects continue through the current Artico events and scoped recovery owners. Each replacement generation retries only `wss://web-chat.io` with its current peer id. It never instantiates an unconfigured Artico peer, retries `0.artico.dev`, or selects another host.
+
+This change does not alter Socket.IO internal reconnect or the separately reviewed WebChat recovery waits. Endpoint selection and retry cadence remain independent concerns and must remain separate commits and pull requests.
+
+## Risks / Trade-offs
+
+- **The single endpoint is unavailable** -> Existing failure and recovery behavior remains visible; do not hide the outage by switching services.
+- **The endpoint accepts a generic WebSocket upgrade but not the pinned Socket.IO protocol** -> Retain an exact `SocketSignaling` readiness probe as operational evidence; generic HTTPS status alone is insufficient.
+- **A future package update changes defaults** -> Constructor controls assert the explicit URL/id composition, while dependency upgrades remain separately reviewed.
+- **Tests accidentally contact production signaling** -> Use only test-owned fakes/mocks in automated suites and assert that no production environment switch exists.
+- **Endpoint and timer changes become coupled** -> Base this authority independently and keep source patches, reviews, and PRs separate.
+
+## Migration Plan
+
+1. Freeze this docs-only authority as a sole child of `86e2787118c74120002a879721841b7a22ce4925`, independently of the recovery-timer change.
+2. On one clean source child, add a deterministic fail-before proving the current composition omits explicit signaling, then implement the exact `SocketSignaling` composition and matching controls.
+3. Run focused Runtime tests and the repository's normal static, build, OpenSpec, and exact-diff gates; confirm no environment, fallback, server, or timer changes entered the candidate.
+4. Obtain fresh independent review of the immutable source exact. Keep the PR Draft and do not merge, deploy, release, or change DNS/certificates/Host/containers/production without separate authority.
+
+Rollback is source-only: revert the explicit signaling composition and its tests. There is no data, protocol, schema, or server migration.

--- a/openspec/changes/set-artico-signaling-endpoint/proposal.md
+++ b/openspec/changes/set-artico-signaling-endpoint/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+WebChat currently creates each Artico peer with only its physical peer id. That leaves the signaling endpoint implicit inside `@rtco/client`, whose pinned default is the vendor-owned `https://0.artico.dev:443`. The browser Runtime must instead select the Owner-provided signaling service explicitly so development and production cannot silently depend on or fall back to the package default.
+
+## What Changes
+
+- Give every production Artico peer generation one explicit built-in `SocketSignaling` configured with the exact secure endpoint `wss://web-chat.io` and the same current physical peer id owned by that room scope.
+- Make `wss://web-chat.io` the sole signaling endpoint shipped by both development and production browser builds. Add no environment selector, endpoint list, fallback, compatibility path, or implicit dependency default.
+- Preserve the built-in Socket.IO signaling protocol: default `/socket.io` path, WebSocket-only transport, current Engine.IO/Socket.IO compatibility, and the existing `id` query identity.
+- Let endpoint failures continue through the existing Artico error, close, and recovery owners. A failure must remain visible to that flow and must never retry through `0.artico.dev` or another endpoint.
+- Keep deterministic tests network-free through test-owned mocks or fakes at the existing dependency/provider boundary; do not add a production test switch or injectable endpoint API.
+- Preserve WebRTC ICE/STUN configuration, per-room peer ownership, peer-id rotation, room identifiers, recovery timing, protocol, public API, persistence, permissions, and dependencies.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `webrtc-runtime`: Bind every browser Artico peer generation to the single owned signaling endpoint without changing signaling protocol or Runtime behavior.
+
+## Impact
+
+- Affected implementation: the Runtime-private Artico transport composition where each scoped physical peer is created.
+- Affected tests: deterministic constructor/composition controls that prove exact URL, matching peer identity, replacement behavior, and absence of fallback.
+- Operational precondition: `web-chat.io` must continue to resolve and present a browser-trusted TLS certificate, and its Socket.IO service must accept the pinned client's default WebSocket handshake. This source change does not own DNS, certificates, hosting, containers, or deployment.
+- Unchanged: peer wire messages and schemas, Socket.IO path/transport/query semantics, room and identity lifecycle, recovery cadence, WebRTC/STUN configuration, public interfaces, persistence, browser manifests, and release/deployment topology.

--- a/openspec/changes/set-artico-signaling-endpoint/specs/webrtc-runtime/spec.md
+++ b/openspec/changes/set-artico-signaling-endpoint/specs/webrtc-runtime/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Browser Artico peers use the single owned signaling endpoint
+
+Every production-owned Artico peer generation in the Runtime-private room transport SHALL use one built-in `SocketSignaling` configured with the exact secure URL `wss://web-chat.io` and the exact current physical `peerId` of its World or Chat room owner. The signaling instance SHALL be passed explicitly to Artico; no production peer SHALL rely on the Artico package's implicit signaling default.
+
+`wss://web-chat.io` SHALL be the sole signaling endpoint shipped in development and production browser builds. Production source SHALL contain no endpoint selector, endpoint list, environment or test branch, localhost alternative, compatibility alias, or fallback to `0.artico.dev` or any other signaling host. Automated tests MAY replace the dependency or existing private provider boundary with test-owned mocks or fakes, but that substitution SHALL add no production configuration or alternate runtime path.
+
+The built-in signaling client's default `/socket.io` path, WebSocket-only transport, current Engine.IO/Socket.IO compatibility, and `id` query SHALL remain unchanged. Normal browser TLS hostname and certificate validation SHALL remain required, with no insecure downgrade or trust bypass. Endpoint failure SHALL continue through the current scoped Artico error, close, and recovery owners and SHALL NOT select another endpoint.
+
+This endpoint selection SHALL NOT change Artico room ownership, physical peer-id generation or rotation, room identifiers, Socket.IO reconnection policy, WebChat recovery timing, WebRTC ICE/STUN configuration, peer protocol, public API, persistence, permissions, dependencies, or browser-specific behavior.
+
+#### Scenario: A scoped peer uses the explicit endpoint and matching identity
+
+- **GIVEN** current World or Chat room demand creates a physical peer owner with a current `peerId`
+- **WHEN** the Runtime starts that owner's Artico peer generation
+- **THEN** it SHALL create exactly one built-in `SocketSignaling` for `wss://web-chat.io` with that same `peerId`, pass it explicitly to Artico, and create no unconfigured or alternate signaling client
+
+#### Scenario: A replacement generation retains endpoint and rotates identity
+
+- **GIVEN** existing scoped recovery replaces a current Artico peer generation and allocates a new physical `peerId`
+- **WHEN** the replacement peer is composed
+- **THEN** its one signaling client SHALL still target `wss://web-chat.io`, SHALL use the new matching `peerId`, and SHALL retain every existing generation and room fence
+
+#### Scenario: Development and production artifacts select one endpoint
+
+- **GIVEN** WebChat is built or run as a development or production browser extension
+- **WHEN** its Runtime creates any real Artico peer
+- **THEN** the sole signaling target SHALL be `wss://web-chat.io`, independent of environment variables, build mode, user settings, or test configuration
+
+#### Scenario: Deterministic tests do not create a production escape path
+
+- **GIVEN** an automated test exercises Artico transport composition without live network access
+- **WHEN** it substitutes a test-owned dependency mock or private-provider fake
+- **THEN** the substitution SHALL remain test-only and production source SHALL still expose no configurable endpoint, alternate signaling branch, or fallback
+
+#### Scenario: Endpoint failure never falls back
+
+- **GIVEN** `wss://web-chat.io` rejects, disconnects, times out, or is temporarily unreachable
+- **WHEN** the current Artico and WebChat recovery owners handle that failure
+- **THEN** every current or replacement signaling attempt SHALL remain scoped to `wss://web-chat.io`, and no attempt SHALL target `0.artico.dev`, localhost, insecure WS/HTTP, or another host
+
+#### Scenario: Socket.IO and WebRTC boundaries remain unchanged
+
+- **GIVEN** the explicit signaling client connects and becomes ready
+- **WHEN** it performs its Socket.IO handshake and the Artico peer joins rooms or negotiates WebRTC
+- **THEN** it SHALL retain the default `/socket.io` path, WebSocket-only transport, current Engine.IO/Socket.IO behavior, and matching `id` query while room messages, recovery timing, and ICE/STUN behavior remain unchanged

--- a/openspec/changes/set-artico-signaling-endpoint/tasks.md
+++ b/openspec/changes/set-artico-signaling-endpoint/tasks.md
@@ -1,0 +1,23 @@
+## 1. Freeze Endpoint And Protocol Authority
+
+- [x] 1.1 Record the current implicit `@rtco/client@0.3.6` endpoint source and freeze `wss://web-chat.io` as the sole development and production browser signaling endpoint with no fallback or environment selector.
+- [x] 1.2 Verify read-only DNS and browser-trusted TLS reachability, exact pinned `SocketSignaling` readiness with matching `id`, and an independent Chromium WebSocket upgrade at the default Socket.IO path.
+- [x] 1.3 Record the unchanged Socket.IO path/transport/query behavior, test-only substitution boundary, failure behavior, WebRTC/STUN configuration, recovery timing, protocol, API, persistence, permissions, and operational ownership.
+
+## 2. Implement Explicit Signaling Composition
+
+- [ ] 2.1 At the existing Runtime-private Artico peer-creation boundary, construct one built-in `SocketSignaling` with exact URL `wss://web-chat.io` and the owner's current physical `peerId`, then pass it explicitly to Artico.
+- [ ] 2.2 Preserve matching initial and replacement peer identity, scoped owner/recovery fencing, default `/socket.io` path, WebSocket-only transport, current Engine.IO/Socket.IO behavior, and existing Artico error/close flow.
+- [ ] 2.3 Add no environment variable, build-mode/test branch, endpoint list, fallback, localhost path, public configuration, dependency upgrade, custom signaling protocol, server change, or recovery-timer change.
+
+## 3. Add Deterministic Controls
+
+- [ ] 3.1 Add a fail-before control proving the released transport creates Artico without explicit signaling and therefore depends on the package default; make the candidate require exact URL, matching `peerId`, and explicit Artico composition through test-owned mocks only.
+- [ ] 3.2 Prove initial World/Chat owners and a replacement generation each create exactly one signaling client at the owned endpoint, with replacement identity rotation and no unconfigured or alternate client.
+- [ ] 3.3 Preserve existing provider behavior and prove endpoint failure remains in the current scoped error/close/recovery path without fallback or changes to room, timer, protocol, API, persistence, or STUN behavior.
+
+## 4. Verify And Review Independently
+
+- [ ] 4.1 Run focused Artico transport controls plus the repository's normal tests, typecheck, format/lint checks, Chrome/Firefox production builds, and strict OpenSpec/status/doctor gates on one implementation exact.
+- [ ] 4.2 Confirm the implementation diff contains only explicit endpoint composition and its deterministic controls, with no recovery-timer PR content or operational infrastructure change.
+- [ ] 4.3 Freeze one clean immutable source exact and obtain fresh independent review; keep its PR Draft and do not merge, deploy, release, or modify DNS, certificates, Host, containers, or production without separate authority.

--- a/src/runtime/ArticoRoomTransport.test.ts
+++ b/src/runtime/ArticoRoomTransport.test.ts
@@ -96,7 +96,26 @@ vi.mock('@rtco/client', () => {
     }
   }
 
-  return { Artico: FakeArtico }
+  return {
+    Artico: FakeArtico,
+    SocketSignaling: class {
+      readonly id = 'fake-signaling'
+      readonly state = 'ready'
+      connect() {}
+      disconnect() {}
+      signal() {}
+      join() {}
+      on() {
+        return this
+      }
+      off() {
+        return this
+      }
+      emit() {
+        return this
+      }
+    }
+  }
 })
 
 import { createArticoRoomTransport } from './ArticoRoomTransport'

--- a/src/runtime/ArticoRoomTransport.ts
+++ b/src/runtime/ArticoRoomTransport.ts
@@ -1,4 +1,4 @@
-import { Artico } from '@rtco/client'
+import { Artico, SocketSignaling } from '@rtco/client'
 import type { Room } from '@rtco/client'
 import { nanoid } from 'nanoid'
 import type { RoomTransport } from '@/runtime/RoomTransport'
@@ -102,7 +102,12 @@ export const createArticoRoomTransport = (): RoomTransport => {
     if (owner.disposed) return
     if (owner.peer) owner.peerId = nanoid()
     retirePeer(owner)
-    const nextPeer = new Artico({ id: owner.peerId })
+    // Every World/Chat Artico generation explicitly uses the owned signaling endpoint with its
+    // own physical peer identity; no env selector, endpoint list, or host fallback exists.
+    const nextPeer = new Artico({
+      id: owner.peerId,
+      signaling: new SocketSignaling({ url: 'wss://web-chat.io', id: owner.peerId })
+    })
     owner.peer = nextPeer
     nextPeer.on('open', () => {
       if (owner.disposed || owners.get(owner.roomId) !== owner || owner.peer !== nextPeer) return

--- a/src/runtime/Server.test.ts
+++ b/src/runtime/Server.test.ts
@@ -126,7 +126,26 @@ vi.mock('@rtco/client', () => {
     close() {}
   }
 
-  return { Artico: FakeArtico }
+  return {
+    Artico: FakeArtico,
+    SocketSignaling: class {
+      readonly id = 'fake-signaling'
+      readonly state = 'ready'
+      connect() {}
+      disconnect() {}
+      signal() {}
+      join() {}
+      on() {
+        return this
+      }
+      off() {
+        return this
+      }
+      emit() {
+        return this
+      }
+    }
+  }
 })
 
 type TestWireMessage = ChatRoomMessage | (WorldRoomMessage & { type?: never })


### PR DESCRIPTION
Child of the docs authority `6239855d` (`docs/set-artico-signaling-endpoint`). All World/Chat Artico generations use `SocketSignaling({ url: 'wss://web-chat.io', id: owner.peerId })`; no env selector/endpoint list/fallback. Existing test mocks supply a test-owned fake signaling. Default /socket.io path, WebSocket-only, TLS/Engine.IO/Socket.IO, STUN/ICE, ownership, recovery timing, protocol/API/persistence/deps unchanged. Draft — no Ready/merge.