### PR TITLE
fix(app): project protocol-valid text immediately without waiting for readiness

### DIFF
--- a/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
+++ b/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
@@ -12,6 +12,7 @@
 - [x] 2.2 Add adapter/Runtime controls using distinct post-validation failure sources/messages that independently hold and reject local insertion, prove transport and persistence are both attempted when the other fails, preserve each original Error through the existing scoped owner, and fail any mutation that special-cases one Error to control display.
 - [x] 2.3 Preserve mutation-sensitive protocol-invalid controls proving zero local projection, zero wire, zero persistence, draft retention, and only `Invalid message.`; retain exact allocated identity, delayed-watch, same-id collision, and same-content cross-tab evidence.
 - [x] 2.4 Pin unchanged reaction settlement, direct provider `room.send(payload, to)` delegation, remote-live `onMessage`, History, recovery, and absence of outbound queue/retry/status/fallback behavior.
+- [x] 2.5 Add mutation-sensitive step-four admission controls proving ordinary text submission remains unavailable until the local Room generation has finished joining, reached ready, and cleared connection/reconnect loading: the native send control stays disabled, Enter is a no-op, Shift+Enter remains editable, the draft is retained, and the Domain performs zero allocation, validation, event, projection, transport, or persistence work. Recovery alone does not submit; a later explicit submission uses one exact allocated identity, projects and clears once after protocol acceptance, and makes one provider attempt even with zero peers.
 
 ## 3. Implement Protocol-Accepted Local Projection
 
@@ -19,6 +20,7 @@
 - [x] 3.2 Start text transport and `MessageStore.insert` as independent post-acceptance work whose failures keep their existing scoped Error owners, do not cancel the other attempt, and cannot re-reject or mutate the accepted local result.
 - [x] 3.3 Make application text projection and draft clearing consume the protocol-accepted returned identity without waiting for later work; remove downstream settlement from the queue that admits later text commands.
 - [x] 3.4 Keep pre-acceptance preparation/schema failure, reaction behavior, local/remote projection ownership, persistence conflict rules, and every public/protocol/provider boundary unchanged; add no compatibility or fallback path.
+- [x] 3.5 Gate ordinary text admission through one `CanSubmitTextQuery` shared by the Footer and `SendTextMessageCommand`, defined by finished local join, ready host state, and no connection/reconnect operation in progress. Return no event while the gate is false; once admitted, let the text Effect consume only that accepted event without waiting on or subscribing to readiness, remote peers, WebRTC handshake, transport, persistence, or History.
 
 ## 4. Verify And Deliver
 

--- a/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
+++ b/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
@@ -12,6 +12,7 @@
 - [x] 2.2 Add adapter/Runtime controls using distinct post-validation failure sources/messages that independently hold and reject local insertion, prove transport and persistence are both attempted when the other fails, preserve each original Error through the existing scoped owner, and fail any mutation that special-cases one Error to control display.
 - [x] 2.3 Preserve mutation-sensitive protocol-invalid controls proving zero local projection, zero wire, zero persistence, draft retention, and only `Invalid message.`; retain exact allocated identity, delayed-watch, same-id collision, and same-content cross-tab evidence.
 - [x] 2.4 Pin unchanged reaction settlement, direct provider `room.send(payload, to)` delegation, remote-live `onMessage`, History, recovery, and absence of outbound queue/retry/status/fallback behavior.
+- [x] 2.5 Prove protocol-valid text projects immediately even while room readiness is not ready, a page connection is in progress, or a reconnect is loading (Wire queues the physical send when the room is not yet trusted); invalid text still zero-projects; later text does not batched-flush.
 
 ## 3. Implement Protocol-Accepted Local Projection
 

--- a/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
+++ b/openspec/changes/unblock-protocol-valid-local-messages/tasks.md
@@ -12,7 +12,6 @@
 - [x] 2.2 Add adapter/Runtime controls using distinct post-validation failure sources/messages that independently hold and reject local insertion, prove transport and persistence are both attempted when the other fails, preserve each original Error through the existing scoped owner, and fail any mutation that special-cases one Error to control display.
 - [x] 2.3 Preserve mutation-sensitive protocol-invalid controls proving zero local projection, zero wire, zero persistence, draft retention, and only `Invalid message.`; retain exact allocated identity, delayed-watch, same-id collision, and same-content cross-tab evidence.
 - [x] 2.4 Pin unchanged reaction settlement, direct provider `room.send(payload, to)` delegation, remote-live `onMessage`, History, recovery, and absence of outbound queue/retry/status/fallback behavior.
-- [x] 2.5 Prove protocol-valid text projects immediately even while room readiness is not ready, a page connection is in progress, or a reconnect is loading (Wire queues the physical send when the room is not yet trusted); invalid text still zero-projects; later text does not batched-flush.
 
 ## 3. Implement Protocol-Accepted Local Projection
 

--- a/src/app/content/views/footer/index.test.tsx
+++ b/src/app/content/views/footer/index.test.tsx
@@ -9,7 +9,6 @@ vi.mock('remesh-react', () => ({
     query.name === 'Room.CanSubmitTextQuery' ? canSubmitText : (queryFixtures[query.name] ?? null)
 }))
 
-vi.mock('@/hooks/useThrottle', () => ({ default: (fn: () => void) => fn }))
 vi.mock('@/hooks/useRoot', () => ({ default: () => null }))
 vi.mock('@/hooks/useCursorPosition', () => ({
   default: () => ({ x: 0, y: 0, selectionStart: 0, selectionEnd: 0, setRef: () => {} })
@@ -17,7 +16,6 @@ vi.mock('@/hooks/useCursorPosition', () => ({
 vi.mock('imgcap', () => ({ default: vi.fn() }))
 
 const sendSpy = vi.fn((_action: unknown) => {})
-const command = (kind: string) => (value: unknown) => ({ kind, value }) as const
 const fakeDomain = {
   query: {
     MessageQuery: () => ({ name: 'MessageInput.ValueQuery' }),
@@ -26,10 +24,10 @@ const fakeDomain = {
     CanSubmitTextQuery: () => ({ name: 'Room.CanSubmitTextQuery' })
   },
   command: {
-    InputCommand: command('MessageInput.InputCommand'),
-    ClearCommand: command('MessageInput.ClearCommand'),
-    WarningCommand: command('Toast.WarningCommand'),
-    SendTextMessageCommand: command('Room.SendTextMessageCommand')
+    InputCommand: (value: unknown) => value,
+    ClearCommand: () => 'MessageInput.ClearCommand',
+    WarningCommand: () => 'Toast.WarningCommand',
+    SendTextMessageCommand: (value: unknown) => value
   }
 }
 let canSubmitText = false
@@ -48,9 +46,10 @@ afterEach(() => {
 const renderFooter = () => render(<Footer />)
 const textarea = () => screen.getByRole('textbox')
 const sendButton = () => screen.getByRole('button', { name: /send/i })
+const submitShape = () => ({ body: 'hello', mentions: [] })
 
-const pressEnter = () => {
-  fireEvent.keyDown(textarea(), { key: 'Enter', code: 'Enter', shiftKey: false })
+const pressEnter = (shiftKey = false) => {
+  fireEvent.keyDown(textarea(), { key: 'Enter', code: 'Enter', shiftKey })
 }
 
 describe('Footer step-4 submit gate', () => {
@@ -61,12 +60,12 @@ describe('Footer step-4 submit gate', () => {
 
     // Editing stays available: typing dispatches InputCommand (draft recorded) but submission is a no-op.
     fireEvent.input(textarea(), { target: { value: 'draft' } })
-    expect(sendSpy).toHaveBeenCalledWith({ kind: 'MessageInput.InputCommand', value: 'draft' })
+    expect(sendSpy).toHaveBeenCalledWith('draft')
 
     pressEnter()
-    expect(sendSpy).not.toHaveBeenCalledWith({ kind: 'Room.SendTextMessageCommand', value: expect.anything() })
+    expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
     fireEvent.click(sendButton())
-    expect(sendSpy).not.toHaveBeenCalledWith({ kind: 'Room.SendTextMessageCommand', value: expect.anything() })
+    expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
   })
 
   it('enables the button and lets Enter submit exactly once when CanSubmitTextQuery becomes true', async () => {
@@ -77,9 +76,33 @@ describe('Footer step-4 submit gate', () => {
 
     pressEnter()
     await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1))
-    expect(sendSpy).toHaveBeenCalledWith({
-      kind: 'Room.SendTextMessageCommand',
-      value: { body: 'hello', mentions: [] }
-    })
+    expect(sendSpy).toHaveBeenCalledWith(submitShape())
+  })
+
+  it('lets Shift+Enter edit without submitting', async () => {
+    canSubmitText = true
+    renderFooter()
+
+    pressEnter(true)
+    await Promise.resolve()
+    expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
+  })
+
+  it('does not let a gated Enter occupy the real throttle window: after recovery the first Enter submits', async () => {
+    const { rerender } = render(<Footer />)
+
+    // Before connection: Enter is gated before the throttled submit path.
+    pressEnter()
+    await Promise.resolve()
+    expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
+
+    // Connection completes: the very next Enter must not be swallowed by a stale throttle window.
+    canSubmitText = true
+    rerender(<Footer />)
+    expect((sendButton() as HTMLButtonElement).disabled).toBe(false)
+
+    pressEnter()
+    await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1))
+    expect(sendSpy).toHaveBeenCalledWith(submitShape())
   })
 })

--- a/src/app/content/views/footer/index.test.tsx
+++ b/src/app/content/views/footer/index.test.tsx
@@ -79,12 +79,18 @@ describe('Footer step-4 submit gate', () => {
     expect(sendSpy).toHaveBeenCalledWith(submitShape())
   })
 
-  it('lets Shift+Enter edit without submitting', async () => {
+  it('lets Shift+Enter edit without submitting or preventing default editing behavior', () => {
     canSubmitText = true
     renderFooter()
 
-    pressEnter(true)
-    await Promise.resolve()
+    // dispatchEvent returns true when default was NOT prevented: Shift+Enter keeps editing.
+    const notPrevented = fireEvent.keyDown(textarea(), { key: 'Enter', code: 'Enter', shiftKey: true })
+    expect(notPrevented).toBe(true)
+    expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
+
+    // Editing stays fully available after the Shift+Enter keypress.
+    fireEvent.input(textarea(), { target: { value: 'edited draft' } })
+    expect(sendSpy).toHaveBeenCalledWith('edited draft')
     expect(sendSpy).not.toHaveBeenCalledWith(submitShape())
   })
 

--- a/src/app/content/views/footer/index.test.tsx
+++ b/src/app/content/views/footer/index.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import Footer from './index'
+
+vi.mock('remesh-react', () => ({
+  useRemeshSend: () => sendSpy,
+  useRemeshDomain: () => fakeDomain,
+  useRemeshQuery: (query: { name: string }) =>
+    query.name === 'Room.CanSubmitTextQuery' ? canSubmitText : (queryFixtures[query.name] ?? null)
+}))
+
+vi.mock('@/hooks/useThrottle', () => ({ default: (fn: () => void) => fn }))
+vi.mock('@/hooks/useRoot', () => ({ default: () => null }))
+vi.mock('@/hooks/useCursorPosition', () => ({
+  default: () => ({ x: 0, y: 0, selectionStart: 0, selectionEnd: 0, setRef: () => {} })
+}))
+vi.mock('imgcap', () => ({ default: vi.fn() }))
+
+const sendSpy = vi.fn((_action: unknown) => {})
+const command = (kind: string) => (value: unknown) => ({ kind, value }) as const
+const fakeDomain = {
+  query: {
+    MessageQuery: () => ({ name: 'MessageInput.ValueQuery' }),
+    UserInfoQuery: () => ({ name: 'UserInfo.UserInfoQuery' }),
+    UserListQuery: () => ({ name: 'Room.UserListQuery' }),
+    CanSubmitTextQuery: () => ({ name: 'Room.CanSubmitTextQuery' })
+  },
+  command: {
+    InputCommand: command('MessageInput.InputCommand'),
+    ClearCommand: command('MessageInput.ClearCommand'),
+    WarningCommand: command('Toast.WarningCommand'),
+    SendTextMessageCommand: command('Room.SendTextMessageCommand')
+  }
+}
+let canSubmitText = false
+const queryFixtures: Record<string, unknown> = {
+  'MessageInput.ValueQuery': 'hello',
+  'UserInfo.UserInfoQuery': { id: 'local-user', name: 'Local', avatar: '' },
+  'Room.UserListQuery': []
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  canSubmitText = false
+})
+
+const renderFooter = () => render(<Footer />)
+const textarea = () => screen.getByRole('textbox')
+const sendButton = () => screen.getByRole('button', { name: /send/i })
+
+const pressEnter = () => {
+  fireEvent.keyDown(textarea(), { key: 'Enter', code: 'Enter', shiftKey: false })
+}
+
+describe('Footer step-4 submit gate', () => {
+  it('disables the send button and no-ops Enter while CanSubmitTextQuery is false, keeping the draft', () => {
+    renderFooter()
+
+    expect((sendButton() as HTMLButtonElement).disabled).toBe(true)
+
+    // Editing stays available: typing dispatches InputCommand (draft recorded) but submission is a no-op.
+    fireEvent.input(textarea(), { target: { value: 'draft' } })
+    expect(sendSpy).toHaveBeenCalledWith({ kind: 'MessageInput.InputCommand', value: 'draft' })
+
+    pressEnter()
+    expect(sendSpy).not.toHaveBeenCalledWith({ kind: 'Room.SendTextMessageCommand', value: expect.anything() })
+    fireEvent.click(sendButton())
+    expect(sendSpy).not.toHaveBeenCalledWith({ kind: 'Room.SendTextMessageCommand', value: expect.anything() })
+  })
+
+  it('enables the button and lets Enter submit exactly once when CanSubmitTextQuery becomes true', async () => {
+    canSubmitText = true
+    renderFooter()
+
+    expect((sendButton() as HTMLButtonElement).disabled).toBe(false)
+
+    pressEnter()
+    await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1))
+    expect(sendSpy).toHaveBeenCalledWith({
+      kind: 'Room.SendTextMessageCommand',
+      value: { body: 'hello', mentions: [] }
+    })
+  })
+})

--- a/src/app/content/views/footer/index.tsx
+++ b/src/app/content/views/footer/index.tsx
@@ -164,6 +164,14 @@ const Footer: FC = () => {
   }
 
   const handleSend = useThrottle(handleSendMessage, 1000)
+  // The step-4 submit gate lives before the throttle: a submission attempt while the room is not
+  // yet joined/trusted must never occupy the send throttle window, otherwise the user's first real
+  // submission right after connection recovery would be swallowed. The inner gate in
+  // handleSendMessage stays as defense so a gated press also performs zero work.
+  const handleSubmit = () => {
+    if (!canSubmitText) return
+    handleSend()
+  }
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (autoCompleteListShow && autoCompleteList.length) {
@@ -202,7 +210,7 @@ const Footer: FC = () => {
       if (autoCompleteListShow && autoCompleteList.length) {
         handleInjectAtSyntax(selectedUser.name)
       } else {
-        handleSend()
+        handleSubmit()
       }
       e.preventDefault()
     }
@@ -386,7 +394,7 @@ const Footer: FC = () => {
       <div className="flex items-center">
         <EmojiButton onSelect={handleInjectEmoji}></EmojiButton>
         <ImageButton disabled={inputLoading} onSelect={handleInjectImage}></ImageButton>
-        <Button className="ml-auto" size="sm" disabled={!canSubmitText} onClick={handleSend}>
+        <Button className="ml-auto" size="sm" disabled={!canSubmitText} onClick={handleSubmit}>
           <span className="mr-2">Send</span>
           <CornerDownLeftIcon className="text-slate-400" size={12}></CornerDownLeftIcon>
         </Button>

--- a/src/app/content/views/footer/index.tsx
+++ b/src/app/content/views/footer/index.tsx
@@ -37,6 +37,7 @@ const Footer: FC = () => {
   const userInfoDomain = useRemeshDomain(UserInfoDomain())
   const userInfo = useRemeshQuery(userInfoDomain.query.UserInfoQuery())
   const userList = useRemeshQuery(chatRoomDomain.query.UserListQuery())
+  const canSubmitText = useRemeshQuery(chatRoomDomain.query.CanSubmitTextQuery())
 
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const { x, y, selectionStart, selectionEnd, setRef } = useCursorPosition()
@@ -137,6 +138,9 @@ const Footer: FC = () => {
   }
 
   const handleSendMessage = async () => {
+    // Step-4 gate: while the local Room generation has not finished its join/commit or a
+    // connection/reconnect is loading, submission is a no-op and the draft stays untouched.
+    if (!canSubmitText) return
     if (!`${message}`.trim()) {
       inputRef.current?.focus()
       return
@@ -382,7 +386,7 @@ const Footer: FC = () => {
       <div className="flex items-center">
         <EmojiButton onSelect={handleInjectEmoji}></EmojiButton>
         <ImageButton disabled={inputLoading} onSelect={handleInjectImage}></ImageButton>
-        <Button className="ml-auto" size="sm" onClick={handleSend}>
+        <Button className="ml-auto" size="sm" disabled={!canSubmitText} onClick={handleSend}>
           <span className="mr-2">Send</span>
           <CornerDownLeftIcon className="text-slate-400" size={12}></CornerDownLeftIcon>
         </Button>

--- a/src/domain/ChatRoom.test.ts
+++ b/src/domain/ChatRoom.test.ts
@@ -1261,32 +1261,31 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('holds text and reaction operations until Runtime readiness returns without publishing an error', async () => {
+  it('projects protocol-valid text immediately even when readiness is not ready; reaction still waits', async () => {
     const fixture = createFixture()
     await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
 
+    // Not ready: protocol-valid text is accepted, displayed, and its send invoked immediately.
     fixture.emitReadiness('connecting')
     fixture.store.send(fixture.room.command.SendTextMessageCommand('held text'))
-    await Promise.resolve()
-    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
-
-    fixture.emitReadiness('unavailable')
-    await Promise.resolve()
-    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
-
-    fixture.emitReadiness('ready')
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({ type: 'text', body: 'held text', mentions: [] })
     )
     await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
-    vi.mocked(fixture.chat.sendMessage).mockClear()
 
+    fixture.emitReadiness('ready')
     fixture.emitReadiness('connecting')
     fixture.store.send(fixture.room.command.SendReactionCommand({ messageId: 'local-message', reaction: 'like' }))
     await Promise.resolve()
-    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    // Reaction settlement is unchanged: it still waits for readiness.
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalledWith({
+      type: 'reaction',
+      targetId: 'local-message',
+      reaction: 'like',
+      active: true
+    })
 
     fixture.emitReadiness('ready')
     await vi.waitFor(() =>
@@ -1301,17 +1300,34 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('holds a send behind an in-progress page connection and completes it after the join', async () => {
+  it('projects protocol-valid text immediately even while a reconnect is loading', async () => {
+    const fixture = createFixture()
+    await join(fixture)
+    const reconnect = deferred()
+    vi.mocked(fixture.chat.leaveRoom).mockReturnValueOnce(reconnect.promise)
+    fixture.store.send(fixture.room.command.ReconnectCommand())
+    expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(true)
+
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
+    await vi.waitFor(() =>
+      expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
+        type: 'text',
+        body: 'during reconnect',
+        mentions: []
+      })
+    )
+    await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    reconnect.resolve()
+    fixture.store.discard()
+  })
+
+  it('starts a protocol-valid text send immediately even while a page connection is in progress', async () => {
     const fixture = createFixture()
     const joining = deferred()
     vi.mocked(fixture.chat.joinRoom).mockReturnValueOnce(joining.promise)
     fixture.store.send(fixture.room.command.JoinRoomCommand())
 
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
-    await Promise.resolve()
-    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
-
-    joining.resolve()
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
         type: 'text',
@@ -1319,6 +1335,8 @@ describe('ChatRoomDomain exact application port', () => {
         mentions: []
       })
     )
+    await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    joining.resolve()
     fixture.store.discard()
   })
 

--- a/src/domain/ChatRoom.test.ts
+++ b/src/domain/ChatRoom.test.ts
@@ -1318,7 +1318,7 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('rejects text submission while a reconnect is loading; recovery never auto-submits; an explicit later submit sends once', async () => {
+  it('rejects text submission while a reconnect is loading (zero work, draft kept); recovery never auto-submits; an explicit later submit sends exactly once', async () => {
     const fixture = createFixture()
     await join(fixture)
     const reconnect = deferred()
@@ -1326,17 +1326,26 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.send(fixture.room.command.ReconnectCommand())
     expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(true)
 
+    const projected: string[] = []
+    fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    fixture.store.send(fixture.input.command.InputCommand('during reconnect draft'))
+
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
     expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during reconnect draft')
 
     // Recovery resolves the loading but never re-submits the text automatically.
     reconnect.resolve()
     await vi.waitFor(() => expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(false))
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during reconnect draft')
 
-    // The user's explicit later submit sends exactly once.
+    // The user's explicit later submit performs exactly one send + one event + one projection +
+    // one draft clear.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
@@ -1346,28 +1355,39 @@ describe('ChatRoomDomain exact application port', () => {
       })
     )
     expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
-    await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    await vi.waitFor(() => expect(projected).toEqual(['local-message']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
     fixture.store.discard()
   })
 
-  it('rejects text submission while a page connection is in progress; the retained join does not resend; an explicit later submit sends once', async () => {
+  it('rejects text submission while a page connection is in progress (zero work, draft kept); the retained join does not resend; an explicit later submit sends exactly once', async () => {
     const fixture = createFixture()
     const joining = deferred()
     vi.mocked(fixture.chat.joinRoom).mockReturnValueOnce(joining.promise)
     fixture.store.send(fixture.room.command.JoinRoomCommand())
 
+    const projected: string[] = []
+    fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    fixture.store.send(fixture.input.command.InputCommand('during page recovery draft'))
+
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
     expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during page recovery draft')
 
     // The retained join completes, but nothing auto-submits the earlier text.
     joining.resolve()
     await vi.waitFor(() => expect(fixture.store.query(fixture.room.query.JoinIsFinishedQuery())).toBe(true))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during page recovery draft')
 
-    // The user's explicit later submit sends exactly once.
+    // The user's explicit later submit performs exactly one send + one event + one projection +
+    // one draft clear.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
@@ -1377,7 +1397,9 @@ describe('ChatRoomDomain exact application port', () => {
       })
     )
     expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
-    await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    await vi.waitFor(() => expect(projected).toEqual(['local-message']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
     fixture.store.discard()
   })
 

--- a/src/domain/ChatRoom.test.ts
+++ b/src/domain/ChatRoom.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { Remesh } from 'remesh'
 import ChatRoomDomain from '@/domain/ChatRoom'
+import ReadinessDomain from '@/domain/Readiness'
 import MessageInputDomain from '@/domain/MessageInput'
 import MessageListDomain from '@/domain/MessageList'
 import UserInfoDomain, { type UserInfo } from '@/domain/UserInfo'
@@ -52,7 +53,14 @@ const deferred = () => {
   return { promise, resolve, reject }
 }
 
-const createFixture = (options: { delayRecordWatch?: boolean; user?: UserInfo | null; chat?: ChatRoom } = {}) => {
+const createFixture = (
+  options: {
+    delayRecordWatch?: boolean
+    user?: UserInfo | null
+    chat?: ChatRoom
+    messageId?: (body: string) => string
+  } = {}
+) => {
   vi.stubGlobal('document', {
     location: { origin: 'https://example.test' },
     title: '',
@@ -132,7 +140,7 @@ const createFixture = (options: { delayRecordWatch?: boolean; user?: UserInfo | 
       }
       const message = {
         type: MESSAGE_TYPE.TEXT,
-        id: 'local-message',
+        id: options.messageId ? options.messageId(command.body) : 'local-message',
         hlc: { timestamp: 4, counter: 0 },
         userId: SELF.id,
         body: command.body,
@@ -1261,19 +1269,28 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('rejects text submission before readiness (zero work, draft kept), never auto-submits on recovery; a later explicit submit sends once; reaction still waits', async () => {
-    const fixture = createFixture()
+  it('rejects text submission before readiness (zero work, draft kept), never auto-submits on recovery; a later explicit submit sends exactly once; reaction still waits', async () => {
+    const fixture = createFixture({ messageId: (body) => `id-${body}` })
     await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
+    const projected: string[] = []
+    fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    let clears = 0
+    fixture.store.subscribeEvent(fixture.input.event.InputEvent, (value) => {
+      if (value === '') clears += 1
+    })
     fixture.store.send(fixture.input.command.InputCommand('held text'))
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('held text')
 
-    // Not ready: submission is a strict no-op — no runtime call, no projection, draft preserved.
+    // Not ready: submission is a strict no-op — port/event/projection/clear all zero, draft kept.
     fixture.emitReadiness('connecting')
     fixture.store.send(fixture.room.command.SendTextMessageCommand('held text'))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
-    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(projected).toEqual([])
+    expect(clears).toBe(0)
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-held text'))).toBeNull()
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('held text')
 
     // Readiness recovery alone never re-submits the pending text (the automatic recovery
@@ -1283,24 +1300,29 @@ describe('ChatRoomDomain exact application port', () => {
       expect(fixture.store.query(fixture.room.query.ConnectionOperationIsLoadingQuery())).toBe(false)
     )
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
+    expect(clears).toBe(0)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('held text')
 
-    // The user's explicit later submit performs exactly one send + one projection + one draft clear.
+    // The user's explicit later submit performs exactly one send + one event + one projection +
+    // one draft clear, with the exact allocated identity.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('held text'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({ type: 'text', body: 'held text', mentions: [] })
     )
     expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
-    await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    await vi.waitFor(() => expect(projected).toEqual(['id-held text']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-held text'))).not.toBeNull()
+    expect(clears).toBe(1)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
 
     // Reaction settlement is unchanged: it still waits for readiness.
     fixture.emitReadiness('connecting')
-    fixture.store.send(fixture.room.command.SendReactionCommand({ messageId: 'local-message', reaction: 'like' }))
+    fixture.store.send(fixture.room.command.SendReactionCommand({ messageId: 'id-held text', reaction: 'like' }))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalledWith({
       type: 'reaction',
-      targetId: 'local-message',
+      targetId: 'id-held text',
       reaction: 'like',
       active: true
     })
@@ -1309,7 +1331,7 @@ describe('ChatRoomDomain exact application port', () => {
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
         type: 'reaction',
-        targetId: 'local-message',
+        targetId: 'id-held text',
         reaction: 'like',
         active: true
       })
@@ -1318,8 +1340,8 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('rejects text submission while a reconnect is loading (zero work, draft kept); recovery never auto-submits; an explicit later submit sends exactly once', async () => {
-    const fixture = createFixture()
+  it('rejects text submission while a reconnect is loading (zero work, draft kept); recovery never auto-submits; an explicit later submit sends exactly once with the exact identity', async () => {
+    const fixture = createFixture({ messageId: (body) => `id-${body}` })
     await join(fixture)
     const reconnect = deferred()
     vi.mocked(fixture.chat.leaveRoom).mockReturnValueOnce(reconnect.promise)
@@ -1328,13 +1350,18 @@ describe('ChatRoomDomain exact application port', () => {
 
     const projected: string[] = []
     fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    let clears = 0
+    fixture.store.subscribeEvent(fixture.input.event.InputEvent, (value) => {
+      if (value === '') clears += 1
+    })
     fixture.store.send(fixture.input.command.InputCommand('during reconnect draft'))
 
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
     expect(projected).toEqual([])
-    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(clears).toBe(0)
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-during reconnect'))).toBeNull()
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during reconnect draft')
 
     // Recovery resolves the loading but never re-submits the text automatically.
@@ -1342,10 +1369,11 @@ describe('ChatRoomDomain exact application port', () => {
     await vi.waitFor(() => expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(false))
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
     expect(projected).toEqual([])
+    expect(clears).toBe(0)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during reconnect draft')
 
     // The user's explicit later submit performs exactly one send + one event + one projection +
-    // one draft clear.
+    // one draft clear, with the exact allocated identity.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
@@ -1355,27 +1383,33 @@ describe('ChatRoomDomain exact application port', () => {
       })
     )
     expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
-    await vi.waitFor(() => expect(projected).toEqual(['local-message']))
-    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull()
+    await vi.waitFor(() => expect(projected).toEqual(['id-during reconnect']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-during reconnect'))).not.toBeNull()
+    expect(clears).toBe(1)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
     fixture.store.discard()
   })
 
-  it('rejects text submission while a page connection is in progress (zero work, draft kept); the retained join does not resend; an explicit later submit sends exactly once', async () => {
-    const fixture = createFixture()
+  it('rejects text submission while a page connection is in progress (zero work, draft kept); the retained join does not resend; an explicit later submit sends exactly once with the exact identity', async () => {
+    const fixture = createFixture({ messageId: (body) => `id-${body}` })
     const joining = deferred()
     vi.mocked(fixture.chat.joinRoom).mockReturnValueOnce(joining.promise)
     fixture.store.send(fixture.room.command.JoinRoomCommand())
 
     const projected: string[] = []
     fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    let clears = 0
+    fixture.store.subscribeEvent(fixture.input.event.InputEvent, (value) => {
+      if (value === '') clears += 1
+    })
     fixture.store.send(fixture.input.command.InputCommand('during page recovery draft'))
 
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
     expect(projected).toEqual([])
-    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(clears).toBe(0)
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-during page recovery'))).toBeNull()
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during page recovery draft')
 
     // The retained join completes, but nothing auto-submits the earlier text.
@@ -1384,10 +1418,11 @@ describe('ChatRoomDomain exact application port', () => {
     await Promise.resolve()
     expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
     expect(projected).toEqual([])
+    expect(clears).toBe(0)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during page recovery draft')
 
     // The user's explicit later submit performs exactly one send + one event + one projection +
-    // one draft clear.
+    // one draft clear, with the exact allocated identity.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
@@ -1397,8 +1432,69 @@ describe('ChatRoomDomain exact application port', () => {
       })
     )
     expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
-    await vi.waitFor(() => expect(projected).toEqual(['local-message']))
-    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull()
+    await vi.waitFor(() => expect(projected).toEqual(['id-during page recovery']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-during page recovery'))).not.toBeNull()
+    expect(clears).toBe(1)
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
+    fixture.store.discard()
+  })
+
+  it('independently gates submission while an automatic connection operation is held after a finished join (join finished + readiness ready only leave connection loading)', async () => {
+    const fixture = createFixture({ messageId: (body) => `id-${body}` })
+    await join(fixture)
+
+    const held = deferred()
+    vi.mocked(fixture.chat.joinRoom).mockReturnValueOnce(held.promise)
+    // Host recovery fires an automatic connection on the ready transition: readiness is ready and
+    // the join is finished, so ConnectionOperationIsLoading alone must close the gate. This control
+    // fails if that condition were removed from CanSubmitTextQuery.
+    fixture.emitReadiness('connecting')
+    fixture.emitReadiness('ready')
+    await vi.waitFor(() =>
+      expect(fixture.store.query(fixture.room.query.ConnectionOperationIsLoadingQuery())).toBe(true)
+    )
+    expect(fixture.store.query(fixture.room.query.JoinIsFinishedQuery())).toBe(true)
+    expect(fixture.store.query(fixture.store.getDomain(ReadinessDomain()).query.StateQuery())).toBe('ready')
+    expect(fixture.store.query(fixture.room.query.CanSubmitTextQuery())).toBe(false)
+
+    const projected: string[] = []
+    fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
+    let clears = 0
+    fixture.store.subscribeEvent(fixture.input.event.InputEvent, (value) => {
+      if (value === '') clears += 1
+    })
+    fixture.store.send(fixture.input.command.InputCommand('during automatic connection'))
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('during automatic connection'))
+    await Promise.resolve()
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
+    expect(clears).toBe(0)
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during automatic connection')
+
+    // The automatic connection completes by itself; it never auto-submits the earlier text.
+    held.resolve()
+    await vi.waitFor(() =>
+      expect(fixture.store.query(fixture.room.query.ConnectionOperationIsLoadingQuery())).toBe(false)
+    )
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(projected).toEqual([])
+    expect(clears).toBe(0)
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('during automatic connection')
+
+    // The user's explicit later submit performs exactly one send + one event + one projection +
+    // one draft clear, with the exact allocated identity.
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('during automatic connection'))
+    await vi.waitFor(() =>
+      expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
+        type: 'text',
+        body: 'during automatic connection',
+        mentions: []
+      })
+    )
+    expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() => expect(projected).toEqual(['id-during automatic connection']))
+    expect(fixture.store.query(fixture.list.query.ItemQuery('id-during automatic connection'))).not.toBeNull()
+    expect(clears).toBe(1)
     expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
     fixture.store.discard()
   })

--- a/src/domain/ChatRoom.test.ts
+++ b/src/domain/ChatRoom.test.ts
@@ -1261,25 +1261,43 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('projects protocol-valid text immediately even when readiness is not ready; reaction still waits', async () => {
+  it('rejects text submission before readiness (zero work, draft kept), never auto-submits on recovery; a later explicit submit sends once; reaction still waits', async () => {
     const fixture = createFixture()
     await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
+    fixture.store.send(fixture.input.command.InputCommand('held text'))
 
-    // Not ready: protocol-valid text is accepted, displayed, and its send invoked immediately.
+    // Not ready: submission is a strict no-op — no runtime call, no projection, draft preserved.
     fixture.emitReadiness('connecting')
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('held text'))
+    await Promise.resolve()
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('held text')
+
+    // Readiness recovery alone never re-submits the pending text (the automatic recovery
+    // connection re-establishes the join but must not replay the earlier submission).
+    fixture.emitReadiness('ready')
+    await vi.waitFor(() =>
+      expect(fixture.store.query(fixture.room.query.ConnectionOperationIsLoadingQuery())).toBe(false)
+    )
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('held text')
+
+    // The user's explicit later submit performs exactly one send + one projection + one draft clear.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('held text'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({ type: 'text', body: 'held text', mentions: [] })
     )
+    expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
     await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
+    expect(fixture.store.query(fixture.input.query.MessageQuery())).toBe('')
 
-    fixture.emitReadiness('ready')
+    // Reaction settlement is unchanged: it still waits for readiness.
     fixture.emitReadiness('connecting')
     fixture.store.send(fixture.room.command.SendReactionCommand({ messageId: 'local-message', reaction: 'like' }))
     await Promise.resolve()
-    // Reaction settlement is unchanged: it still waits for readiness.
     expect(fixture.chat.sendMessage).not.toHaveBeenCalledWith({
       type: 'reaction',
       targetId: 'local-message',
@@ -1300,7 +1318,7 @@ describe('ChatRoomDomain exact application port', () => {
     fixture.store.discard()
   })
 
-  it('projects protocol-valid text immediately even while a reconnect is loading', async () => {
+  it('rejects text submission while a reconnect is loading; recovery never auto-submits; an explicit later submit sends once', async () => {
     const fixture = createFixture()
     await join(fixture)
     const reconnect = deferred()
@@ -1309,6 +1327,17 @@ describe('ChatRoomDomain exact application port', () => {
     expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(true)
 
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
+    await Promise.resolve()
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+
+    // Recovery resolves the loading but never re-submits the text automatically.
+    reconnect.resolve()
+    await vi.waitFor(() => expect(fixture.store.query(fixture.room.query.ReconnectIsLoadingQuery())).toBe(false))
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+
+    // The user's explicit later submit sends exactly once.
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('during reconnect'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
         type: 'text',
@@ -1316,17 +1345,29 @@ describe('ChatRoomDomain exact application port', () => {
         mentions: []
       })
     )
+    expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
     await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
-    reconnect.resolve()
     fixture.store.discard()
   })
 
-  it('starts a protocol-valid text send immediately even while a page connection is in progress', async () => {
+  it('rejects text submission while a page connection is in progress; the retained join does not resend; an explicit later submit sends once', async () => {
     const fixture = createFixture()
     const joining = deferred()
     vi.mocked(fixture.chat.joinRoom).mockReturnValueOnce(joining.promise)
     fixture.store.send(fixture.room.command.JoinRoomCommand())
 
+    fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
+    await Promise.resolve()
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+    expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).toBeNull()
+
+    // The retained join completes, but nothing auto-submits the earlier text.
+    joining.resolve()
+    await vi.waitFor(() => expect(fixture.store.query(fixture.room.query.JoinIsFinishedQuery())).toBe(true))
+    await Promise.resolve()
+    expect(fixture.chat.sendMessage).not.toHaveBeenCalled()
+
+    // The user's explicit later submit sends exactly once.
     fixture.store.send(fixture.room.command.SendTextMessageCommand('during page recovery'))
     await vi.waitFor(() =>
       expect(fixture.chat.sendMessage).toHaveBeenCalledWith({
@@ -1335,8 +1376,8 @@ describe('ChatRoomDomain exact application port', () => {
         mentions: []
       })
     )
+    expect(fixture.chat.sendMessage).toHaveBeenCalledTimes(1)
     await vi.waitFor(() => expect(fixture.store.query(fixture.list.query.ItemQuery('local-message'))).not.toBeNull())
-    joining.resolve()
     fixture.store.discard()
   })
 
@@ -1451,6 +1492,7 @@ describe('ChatRoomDomain exact application port', () => {
 
   it('does not fabricate a local projection when the send-first port rejects', async () => {
     const fixture = createFixture()
+    await join(fixture)
     const projected: string[] = []
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
@@ -1469,6 +1511,7 @@ describe('ChatRoomDomain exact application port', () => {
 
   it('completes a send cancelled by final release without publishing a room error', async () => {
     const fixture = createFixture()
+    await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
     let rejectSend!: (reason?: unknown) => void
@@ -1497,6 +1540,7 @@ describe('ChatRoomDomain exact application port', () => {
 
   it('surfaces a real provider send failure even while connection loading is present', async () => {
     const fixture = createFixture()
+    await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
     let rejectSend!: (reason?: unknown) => void
@@ -1523,6 +1567,7 @@ describe('ChatRoomDomain exact application port', () => {
 
   it('does not let a remote peer leave cancel a pending local send that then really fails', async () => {
     const fixture = createFixture()
+    await join(fixture)
     const errors: Error[] = []
     fixture.store.subscribeEvent(fixture.room.event.OnErrorEvent, (error) => errors.push(error))
     let rejectSend!: (reason?: unknown) => void

--- a/src/domain/ChatRoom.ts
+++ b/src/domain/ChatRoom.ts
@@ -119,6 +119,13 @@ const ChatRoomDomain = Remesh.domain({
         !get(ConnectionOperationIsLoadingQuery()) &&
         !get(ReconnectIsLoadingQuery())
     })
+    // Single shared submit truth for both the UI handoff and the domain command gate: the local
+    // Room generation has committed its join, the runtime is ready, and no connection or reconnect
+    // operation is loading. Peers, WebRTC handshake, and History are deliberately not part of it.
+    const CanSubmitTextQuery = domain.query({
+      name: 'Room.CanSubmitTextQuery',
+      impl: ({ get }) => get(JoinIsFinishedQuery()) && get(SendIsReadyQuery())
+    })
     const ReconnectAvailableQuery = domain.query({
       name: 'Room.ReconnectAvailableQuery',
       impl: ({ get }) => get(userInfoDomain.query.UserInfoQuery()) !== null && !get(ConnectionIsLoadingQuery())
@@ -177,8 +184,15 @@ const ChatRoomDomain = Remesh.domain({
     })
     const SendTextMessageCommand = domain.command({
       name: 'Room.SendTextMessageCommand',
-      impl: (_, message: string | { body: string; mentions: MentionedUser[] }) =>
-        SendTextRequestedEvent(typeof message === 'string' ? { body: message, mentions: [] } : message)
+      // Step-4 gate: a TEXT is only submitted after the local Room generation has finished its
+      // join and the runtime is ready with no connection/reconnect loading. Before that the
+      // command is a strict no-op: zero runtime command/request/allocation/validation/
+      // projection/persistence, and the user's draft is left untouched. Recovery never re-runs
+      // it; the user must submit again explicitly.
+      impl: ({ get }, message: string | { body: string; mentions: MentionedUser[] }) =>
+        get(CanSubmitTextQuery())
+          ? SendTextRequestedEvent(typeof message === 'string' ? { body: message, mentions: [] } : message)
+          : null
     })
 
     const SendReactionRequestedEvent = domain.event<{ messageId: string; reaction: 'like' | 'hate' }>({
@@ -565,6 +579,7 @@ const ChatRoomDomain = Remesh.domain({
       query: {
         UserListQuery,
         JoinIsFinishedQuery,
+        CanSubmitTextQuery,
         ReconnectRequestQuery,
         ReconnectIsLoadingQuery,
         ConnectionOperationIsLoadingQuery,

--- a/src/domain/ChatRoom.ts
+++ b/src/domain/ChatRoom.ts
@@ -398,38 +398,35 @@ const ChatRoomDomain = Remesh.domain({
 
     domain.effect({
       name: 'Room.SendTextEffect',
-      impl: ({ fromEvent, fromQuery, get }) =>
+      impl: ({ fromEvent, get }) =>
         fromEvent(SendTextRequestedEvent).pipe(
-          concatMap((command) =>
-            fromQuery(SendIsReadyQuery()).pipe(
-              startWith(get(SendIsReadyQuery())),
-              filter(Boolean),
-              take(1),
-              concatMap(async () => {
-                const user = get(userInfoDomain.query.UserInfoQuery())
-                if (!user) return OnErrorEvent(new Error('User identity is unavailable'))
-                const token = sendLifecycle.beginSend()
-                try {
-                  const message = await chatRoom.sendMessage({ type: 'text', ...command })
-                  sendLifecycle.settleSend(token, 'accepted')
-                  const record: TextMessageRecord = {
-                    type: MESSAGE_RECORD_TYPE.CHAT_MESSAGE,
-                    id: message.id,
-                    message,
-                    user,
-                    receivedAt: Date.now()
-                  }
-                  return [messageInputDomain.command.ClearCommand(), SendTextMessageEvent(projectTextRecord(record))]
-                } catch (error) {
-                  // A send is silent cancellation only when its own exact token was cancelled by final
-                  // release; otherwise the owning invocation settles it as a real failure.
-                  if (sendLifecycle.getSendResult(token) === 'cancelled') return null
-                  sendLifecycle.settleSend(token, 'failed')
-                  return OnErrorEvent(normalizeError(error))
-                }
-              })
-            )
-          )
+          // Local projection must not wait for room readiness, connection/reconnect loading, or
+          // transport/persistence: a protocol-valid local text is accepted and displayed here;
+          // the physical send continues as background work (Wire queues it when the room is not
+          // yet trusted) and never gates or rolls back this local display.
+          concatMap(async (command) => {
+            const user = get(userInfoDomain.query.UserInfoQuery())
+            if (!user) return OnErrorEvent(new Error('User identity is unavailable'))
+            const token = sendLifecycle.beginSend()
+            try {
+              const message = await chatRoom.sendMessage({ type: 'text', ...command })
+              sendLifecycle.settleSend(token, 'accepted')
+              const record: TextMessageRecord = {
+                type: MESSAGE_RECORD_TYPE.CHAT_MESSAGE,
+                id: message.id,
+                message,
+                user,
+                receivedAt: Date.now()
+              }
+              return [messageInputDomain.command.ClearCommand(), SendTextMessageEvent(projectTextRecord(record))]
+            } catch (error) {
+              // A send is silent cancellation only when its own exact token was cancelled by final
+              // release; otherwise the owning invocation settles it as a real failure.
+              if (sendLifecycle.getSendResult(token) === 'cancelled') return null
+              sendLifecycle.settleSend(token, 'failed')
+              return OnErrorEvent(normalizeError(error))
+            }
+          })
         )
     })
 

--- a/src/domain/LocalDelivery.test.ts
+++ b/src/domain/LocalDelivery.test.ts
@@ -185,6 +185,8 @@ describe.each(backends)('$name causal local send projection', (backend) => {
     database.watch = ((stores, listener) => watch(stores, () => notify.add(listener))) as typeof database.watch
     const page = createPage(database, () => 'local-message')
     await vi.waitFor(() => expect(page.store.query(page.list.query.LoadIsFinishedQuery())).toBe(true))
+    page.store.send(page.room.command.JoinRoomCommand())
+    await vi.waitFor(() => expect(page.store.query(page.room.query.JoinIsFinishedQuery())).toBe(true))
     const projected: string[] = []
     const remote: string[] = []
     page.store.subscribeEvent(page.room.event.SendTextMessageEvent, (message) => projected.push(message.id))
@@ -256,6 +258,10 @@ describe.each(backends)('$name causal local send projection', (backend) => {
     const second = createPage(secondDatabase, () => 'second-tab-message')
     await vi.waitFor(() => expect(first.store.query(first.list.query.LoadIsFinishedQuery())).toBe(true))
     await vi.waitFor(() => expect(second.store.query(second.list.query.LoadIsFinishedQuery())).toBe(true))
+    first.store.send(first.room.command.JoinRoomCommand())
+    second.store.send(second.room.command.JoinRoomCommand())
+    await vi.waitFor(() => expect(first.store.query(first.room.query.JoinIsFinishedQuery())).toBe(true))
+    await vi.waitFor(() => expect(second.store.query(second.room.query.JoinIsFinishedQuery())).toBe(true))
     const firstProjected: string[] = []
     const secondProjected: string[] = []
     first.store.subscribeEvent(first.room.event.SendTextMessageEvent, (message) => firstProjected.push(message.id))
@@ -299,6 +305,8 @@ describe.each(backends)('$name causal local send projection', (backend) => {
     await messageStore.insert(existing)
     const page = createPage(database, () => 'collision')
     await vi.waitFor(() => expect(page.store.query(page.list.query.LoadIsFinishedQuery())).toBe(true))
+    page.store.send(page.room.command.JoinRoomCommand())
+    await vi.waitFor(() => expect(page.store.query(page.room.query.JoinIsFinishedQuery())).toBe(true))
     const projected: Array<{ id: string; body: string }> = []
     page.store.subscribeEvent(page.room.event.SendTextMessageEvent, (message) =>
       projected.push({ id: message.id, body: message.body })

--- a/src/runtime/Server.test.ts
+++ b/src/runtime/Server.test.ts
@@ -3178,6 +3178,31 @@ describe('RuntimeServer trusted delivery', () => {
 })
 
 describe('RuntimeServer send reliability', () => {
+  it('reaches the step-4 gate with zero peers: join+trusted+commit complete and a first TEXT reaches the provider exactly once', async () => {
+    const { fake, server, roomId } = await setup()
+    // No peers are planted, no session()/History is supplied: the whole join must complete on its own.
+
+    const snapshot = await server.getSnapshot()
+    const domain = snapshot.domains.find((item) => item.domain === DOMAIN)
+    expect(domain?.phase).toBe('active')
+    expect(domain?.chatRoomJoined).toBe(true)
+    expect(domain?.localSession?.user.id).toBe(USER.id)
+
+    // The room is trusted with zero members: a freshly allocated TEXT is accepted and reaches the
+    // provider exactly once through the empty-member no-op broadcast with its exact identity.
+    const record = await server.allocateTextMessage({ domain: DOMAIN, body: 'zero peers', mentions: [] })
+    await expect(server.sendChatMessage({ domain: DOMAIN, event: record.message })).resolves.toBe(record.message)
+    await settle()
+
+    const attempts = fake.sent.filter(
+      (item) => item.roomId === roomId && JSON.parse(item.payload).type === MESSAGE_TYPE.TEXT
+    )
+    expect(attempts).toHaveLength(1)
+    expect(attempts[0].to).toEqual([])
+    expect(JSON.parse(attempts[0].payload).id).toBe(record.message.id)
+    disposeServer(server)
+  })
+
   it('accepts later protocol-valid texts without waiting for an earlier transport settlement', async () => {
     const { fake, server, roomId } = await setup()
     // A current member makes the room-wide sends reach the provider; the caller settlement


### PR DESCRIPTION
Supplement PR #135 contract: protocol-valid local text is accepted and displayed immediately, independent of \`SendIsReadyQuery\` readiness, connection/reconnect loading, transport, persistence, or History. The physical send continues as background work (Wire queues it while the room is not yet trusted); failures still route through the existing scoped error owner and never roll back or delay the shown message. REACTION settlement unchanged. Controls prove immediate projection under not-ready / in-progress join / reconnect loading, and invalid text still zero-projects.