### PR TITLE
docs(architecture): add runtime lifecycle diagram

### DIFF
--- a/docs/architecture/webchat-runtime-lifecycle.html
+++ b/docs/architecture/webchat-runtime-lifecycle.html
@@ -1,0 +1,1722 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="generator" content="archify 2.11.0" />
+    <title>WebChat Runtime Lifecycle Diagram</title>
+    <script>
+      // Resolve the theme before first paint so light-preference users don't
+      // see a dark flash. The toolbar script below re-applies with UI state.
+      ;(function () {
+        try {
+          var theme = null
+          try {
+            var param = new URLSearchParams(window.location.search).get('theme')
+            if (param === 'light' || param === 'dark') theme = param
+          } catch (_) {}
+          if (!theme) {
+            try {
+              theme = localStorage.getItem('archify-theme')
+            } catch (_) {}
+          }
+          if (theme !== 'light' && theme !== 'dark') {
+            theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+          }
+          document.documentElement.setAttribute('data-theme', theme)
+        } catch (_) {}
+      })()
+    </script>
+    <!-- Async font load: a blackholed network must not block first paint.
+       The body font stack falls back to system monospace until it lands. -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+      media="print"
+      onload="this.media = 'all'"
+    />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
+    <style>
+      /* ==========================================================
+       THEME VARIABLES — switch by toggling [data-theme] on <html>
+       ========================================================== */
+      :root,
+      [data-theme='dark'] {
+        --bg: #020617;
+        --grid: #1e293b;
+        --text: #ffffff;
+        --text-muted: #94a3b8;
+        --text-dim: #475569;
+        /* UI chrome (menu hints, footer) needs more contrast than SVG .t-dim accents */
+        --text-faint: #7d8da1;
+
+        --panel: rgba(15, 23, 42, 0.5);
+        --panel-border: #1e293b;
+        --lane-fill: rgba(15, 23, 42, 0.22);
+        --lane-stroke: #334155;
+
+        --arrow: #64748b;
+        --arrow-emphasis: #34d399;
+
+        /* Opaque mask color used behind semi-transparent component fills
+         so the arrows drawn underneath are properly hidden. */
+        --mask: #0f172a;
+
+        --frontend-fill: rgba(8, 51, 68, 0.4);
+        --frontend-stroke: #22d3ee;
+        --backend-fill: rgba(6, 78, 59, 0.4);
+        --backend-stroke: #34d399;
+        --database-fill: rgba(76, 29, 149, 0.4);
+        --database-stroke: #a78bfa;
+        --cloud-fill: rgba(120, 53, 15, 0.3);
+        --cloud-stroke: #fbbf24;
+        --security-fill: rgba(136, 19, 55, 0.4);
+        --security-stroke: #fb7185;
+        --messagebus-fill: rgba(251, 146, 60, 0.3);
+        --messagebus-stroke: #fb923c;
+        --external-fill: rgba(30, 41, 59, 0.5);
+        --external-stroke: #94a3b8;
+
+        --toolbar-bg: rgba(15, 23, 42, 0.8);
+        --toolbar-border: #334155;
+        --toolbar-text: #e2e8f0;
+        --toolbar-hover: rgba(15, 23, 42, 0.95);
+        --toolbar-menu-bg: #0f172a;
+      }
+
+      [data-theme='light'] {
+        --bg: #f8fafc;
+        --grid: #e2e8f0;
+        --text: #0f172a;
+        --text-muted: #64748b;
+        --text-dim: #94a3b8;
+        --text-faint: #64748b;
+
+        --panel: #ffffff;
+        --panel-border: #e2e8f0;
+        --lane-fill: rgba(248, 250, 252, 0.65);
+        --lane-stroke: #cbd5e1;
+
+        --arrow: #94a3b8;
+        --arrow-emphasis: #059669;
+
+        --mask: #ffffff;
+
+        --frontend-fill: rgba(34, 211, 238, 0.15);
+        --frontend-stroke: #0891b2;
+        --backend-fill: rgba(52, 211, 153, 0.18);
+        --backend-stroke: #059669;
+        --database-fill: rgba(167, 139, 250, 0.2);
+        --database-stroke: #7c3aed;
+        --cloud-fill: rgba(251, 191, 36, 0.18);
+        --cloud-stroke: #d97706;
+        --security-fill: rgba(251, 113, 133, 0.15);
+        --security-stroke: #e11d48;
+        --messagebus-fill: rgba(251, 146, 60, 0.15);
+        --messagebus-stroke: #ea580c;
+        --external-fill: rgba(148, 163, 184, 0.18);
+        --external-stroke: #64748b;
+
+        --toolbar-bg: rgba(255, 255, 255, 0.92);
+        --toolbar-border: #cbd5e1;
+        --toolbar-text: #334155;
+        --toolbar-hover: #ffffff;
+        --toolbar-menu-bg: #ffffff;
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family:
+          'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono',
+          'Noto Sans Mono CJK SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', monospace;
+        background: var(--bg);
+        min-height: 100vh;
+        padding: 2rem;
+        color: var(--text);
+        transition:
+          background 0.2s ease,
+          color 0.2s ease;
+      }
+
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .header {
+        margin-bottom: 2rem;
+      }
+
+      .header-row {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .pulse-dot {
+        width: 12px;
+        height: 12px;
+        background: var(--frontend-stroke);
+        border-radius: 50%;
+        animation: pulse 2s infinite;
+      }
+
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.5;
+        }
+      }
+
+      h1 {
+        font-size: 1.5rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+      }
+
+      .subtitle {
+        color: var(--text-muted);
+        font-size: 0.875rem;
+        margin-left: 1.75rem;
+      }
+
+      .diagram-container {
+        background: var(--panel);
+        border-radius: 1rem;
+        border: 1px solid var(--panel-border);
+        padding: 1.5rem;
+        overflow-x: auto;
+      }
+
+      svg {
+        width: 100%;
+        min-width: min(900px, 100%);
+        display: block;
+      }
+
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+        margin-top: 2rem;
+      }
+
+      .card {
+        background: var(--panel);
+        border-radius: 0.75rem;
+        border: 1px solid var(--panel-border);
+        padding: 1.25rem;
+      }
+
+      .card-header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .card-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+      }
+
+      .card-dot.cyan {
+        background: var(--frontend-stroke);
+      }
+      .card-dot.emerald {
+        background: var(--backend-stroke);
+      }
+      .card-dot.violet {
+        background: var(--database-stroke);
+      }
+      .card-dot.amber {
+        background: var(--cloud-stroke);
+      }
+      .card-dot.rose {
+        background: var(--security-stroke);
+      }
+      .card-dot.orange {
+        background: var(--messagebus-stroke);
+      }
+      .card-dot.slate {
+        background: var(--external-stroke);
+      }
+
+      .card h3 {
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--text);
+      }
+
+      .card ul {
+        list-style: none;
+        color: var(--text-muted);
+        font-size: 0.75rem;
+      }
+
+      .card li {
+        margin-bottom: 0.375rem;
+      }
+
+      .footer {
+        text-align: center;
+        margin-top: 1.5rem;
+        color: var(--text-faint);
+        font-size: 0.75rem;
+      }
+
+      /* ==========================================================
+       Print stylesheet — hide interactive controls, force light,
+       drop the grid so the diagram doesn't waste ink, use landscape
+       so wide diagrams fit, pack summary cards into 2 columns to
+       avoid an orphan card on a trailing page.
+       ========================================================== */
+      @page {
+        size: landscape;
+        margin: 1.5cm;
+      }
+
+      @media print {
+        /* Force the FULL light palette — including component fills/strokes and
+         lane/arrow colors — so printing from dark theme doesn't put neon
+         strokes and translucent dark fills on white paper. */
+        :root,
+        [data-theme='dark'],
+        [data-theme='light'] {
+          --bg: #ffffff;
+          --grid: transparent;
+          --panel: #ffffff;
+          --panel-border: #e2e8f0;
+          --text: #0f172a;
+          --text-muted: #475569;
+          --text-dim: #94a3b8;
+          --text-faint: #64748b;
+          --mask: #ffffff;
+          --lane-fill: rgba(248, 250, 252, 0.65);
+          --lane-stroke: #cbd5e1;
+          --arrow: #94a3b8;
+          --arrow-emphasis: #059669;
+          --frontend-fill: rgba(34, 211, 238, 0.15);
+          --frontend-stroke: #0891b2;
+          --backend-fill: rgba(52, 211, 153, 0.18);
+          --backend-stroke: #059669;
+          --database-fill: rgba(167, 139, 250, 0.2);
+          --database-stroke: #7c3aed;
+          --cloud-fill: rgba(251, 191, 36, 0.18);
+          --cloud-stroke: #d97706;
+          --security-fill: rgba(251, 113, 133, 0.15);
+          --security-stroke: #e11d48;
+          --messagebus-fill: rgba(251, 146, 60, 0.15);
+          --messagebus-stroke: #ea580c;
+          --external-fill: rgba(148, 163, 184, 0.18);
+          --external-stroke: #64748b;
+        }
+        body {
+          background: #ffffff !important;
+          padding: 0;
+        }
+        .container {
+          max-width: none;
+        }
+        .toolbar,
+        .archify-toast,
+        .no-print {
+          display: none !important;
+        }
+        .diagram-container,
+        .card {
+          box-shadow: none;
+          border-color: #e2e8f0;
+        }
+        .cards {
+          grid-template-columns: 1fr 1fr;
+        }
+        /* Ensure elements break sensibly across pages */
+        .card {
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+        .diagram-container {
+          break-inside: avoid;
+          page-break-inside: avoid;
+        }
+        h1,
+        .subtitle {
+          color: #0f172a;
+        }
+      }
+
+      /* ==========================================================
+       TOOLBAR (theme toggle + export menu)
+       ========================================================== */
+      .toolbar {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        display: flex;
+        gap: 0.5rem;
+        z-index: 100;
+      }
+      .toolbar button {
+        background: var(--toolbar-bg);
+        color: var(--toolbar-text);
+        border: 1px solid var(--toolbar-border);
+        padding: 0.5rem 0.875rem;
+        border-radius: 0.5rem;
+        font-family: inherit;
+        font-size: 0.75rem;
+        font-weight: 500;
+        cursor: pointer;
+        backdrop-filter: blur(8px);
+        transition:
+          background 0.15s,
+          border-color 0.15s;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.375rem;
+      }
+      .toolbar button:hover {
+        background: var(--toolbar-hover);
+        border-color: var(--arrow);
+      }
+      .toolbar button:focus-visible {
+        outline: 2px solid var(--frontend-stroke);
+        outline-offset: 2px;
+      }
+      .toolbar .export-wrap {
+        position: relative;
+      }
+      .toolbar .export-menu {
+        position: absolute;
+        top: calc(100% + 0.375rem);
+        right: 0;
+        background: var(--toolbar-menu-bg);
+        border: 1px solid var(--toolbar-border);
+        border-radius: 0.5rem;
+        padding: 0.375rem;
+        min-width: 160px;
+        display: none;
+        flex-direction: column;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+      }
+      .toolbar .export-menu.open {
+        display: flex;
+      }
+      .toolbar .export-menu button {
+        background: transparent;
+        border: 0;
+        justify-content: space-between;
+        width: 100%;
+        text-align: left;
+        padding: 0.5rem 0.75rem;
+      }
+      .toolbar .export-menu button:hover {
+        background: var(--toolbar-hover);
+      }
+      .toolbar .export-menu .hint {
+        color: var(--text-faint);
+        font-size: 0.625rem;
+      }
+      .toolbar .export-menu hr {
+        border: 0;
+        border-top: 1px solid var(--toolbar-border);
+        margin: 0.25rem 0.375rem;
+        opacity: 0.5;
+      }
+
+      /* Toast — brief feedback for actions like "copied" */
+      .archify-toast {
+        position: fixed;
+        top: 1rem;
+        left: 50%;
+        transform: translateX(-50%) translateY(-8px);
+        background: var(--toolbar-menu-bg);
+        color: var(--text);
+        border: 1px solid var(--toolbar-border);
+        padding: 0.5rem 1rem;
+        border-radius: 0.5rem;
+        font-family: inherit;
+        font-size: 0.75rem;
+        opacity: 0;
+        transition:
+          opacity 0.2s,
+          transform 0.2s;
+        z-index: 200;
+        pointer-events: none;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+      }
+      .archify-toast.show {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+      }
+
+      @media (max-width: 720px) {
+        body {
+          padding: 1rem;
+        }
+        .toolbar {
+          position: static;
+          justify-content: flex-end;
+          margin-bottom: 1rem;
+        }
+        .header {
+          margin-bottom: 1.25rem;
+        }
+        .header-row {
+          gap: 0.75rem;
+          align-items: flex-start;
+        }
+        h1 {
+          font-size: 1.25rem;
+          line-height: 1.25;
+        }
+        .subtitle {
+          margin-left: 0;
+          font-size: 0.8125rem;
+          line-height: 1.55;
+        }
+        .diagram-container {
+          padding: 0.75rem;
+          border-radius: 0.75rem;
+        }
+        .cards {
+          grid-template-columns: 1fr;
+          margin-top: 1rem;
+        }
+      }
+
+      /* ==========================================================
+       SVG SEMANTIC CLASSES — use these instead of inline fill/stroke
+       ========================================================== */
+      .c-grid {
+        stroke: var(--grid);
+        fill: none;
+      }
+      .c-mask {
+        fill: var(--mask);
+        stroke: none;
+      }
+
+      .c-frontend {
+        fill: var(--frontend-fill);
+        stroke: var(--frontend-stroke);
+      }
+      .c-backend {
+        fill: var(--backend-fill);
+        stroke: var(--backend-stroke);
+      }
+      .c-database {
+        fill: var(--database-fill);
+        stroke: var(--database-stroke);
+      }
+      .c-cloud {
+        fill: var(--cloud-fill);
+        stroke: var(--cloud-stroke);
+      }
+      .c-security {
+        fill: var(--security-fill);
+        stroke: var(--security-stroke);
+      }
+      .c-messagebus {
+        fill: var(--messagebus-fill);
+        stroke: var(--messagebus-stroke);
+      }
+      .c-external {
+        fill: var(--external-fill);
+        stroke: var(--external-stroke);
+      }
+
+      /* Text helpers */
+      .t-primary {
+        fill: var(--text);
+      }
+      .t-muted {
+        fill: var(--text-muted);
+      }
+      .t-dim {
+        fill: var(--text-dim);
+      }
+      .t-frontend {
+        fill: var(--frontend-stroke);
+      }
+      .t-backend {
+        fill: var(--backend-stroke);
+      }
+      .t-database {
+        fill: var(--database-stroke);
+      }
+      .t-cloud {
+        fill: var(--cloud-stroke);
+      }
+      .t-security {
+        fill: var(--security-stroke);
+      }
+      .t-messagebus {
+        fill: var(--messagebus-stroke);
+      }
+      .t-external {
+        fill: var(--external-stroke);
+      }
+
+      /* Arrows */
+      .a-default {
+        stroke: var(--arrow);
+        fill: none;
+      }
+      .a-emphasis {
+        stroke: var(--arrow-emphasis);
+        fill: none;
+      }
+      .a-security {
+        stroke: var(--security-stroke);
+        fill: none;
+        stroke-dasharray: 5, 5;
+      }
+      .a-dashed {
+        stroke: var(--database-stroke);
+        fill: none;
+        stroke-dasharray: 4, 4;
+      }
+
+      /* Arrowhead markers reference these */
+      .m-default {
+        fill: var(--arrow);
+      }
+      .m-emphasis {
+        fill: var(--arrow-emphasis);
+      }
+      .m-security {
+        fill: var(--security-stroke);
+      }
+      .m-dashed {
+        fill: var(--database-stroke);
+      }
+
+      /* Dashed boundary variants */
+      .c-security-group {
+        fill: transparent;
+        stroke: var(--security-stroke);
+        stroke-dasharray: 4, 4;
+      }
+      .c-region {
+        fill: rgba(251, 191, 36, 0.05);
+        stroke: var(--cloud-stroke);
+        stroke-dasharray: 8, 4;
+      }
+      .c-lane {
+        fill: var(--lane-fill);
+        stroke: var(--lane-stroke);
+        stroke-dasharray: 6, 6;
+      }
+
+      /* Optional trace animation, enabled only by meta.animation = "trace".
+       Static diagrams do not carry data-animation and render exactly as before. */
+      svg[data-animation='trace'] [data-animate='edge'] {
+        stroke-dasharray: 10 8;
+        stroke-dashoffset: 54;
+        animation: archify-edge-flow 2.4s linear infinite;
+        animation-delay: calc(var(--step, 0) * 160ms);
+      }
+      svg[data-animation='trace'] [data-animate='node'] {
+        transform-box: fill-box;
+        transform-origin: center;
+        animation: archify-node-pulse 3.6s ease-in-out infinite;
+        animation-delay: calc(var(--step, 0) * 160ms);
+      }
+      @keyframes archify-edge-flow {
+        to {
+          stroke-dashoffset: 0;
+        }
+      }
+      @keyframes archify-node-pulse {
+        0%,
+        72%,
+        100% {
+          filter: none;
+          stroke-width: 1.5;
+        }
+        18%,
+        36% {
+          filter: drop-shadow(0 0 8px var(--arrow-emphasis));
+          stroke-width: 2.4;
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        svg[data-animation='trace'] [data-animate] {
+          animation: none !important;
+          stroke-dashoffset: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Toolbar: theme toggle + export menu (present on every generated diagram)
+       Keyboard: T toggles theme, E opens export menu (when no input focused) -->
+    <div class="toolbar" role="toolbar" aria-label="Diagram actions">
+      <button
+        id="btn-theme"
+        type="button"
+        title="Toggle theme (T)"
+        aria-label="Toggle color theme"
+        aria-pressed="false"
+      >
+        <span id="theme-icon" aria-hidden="true">&#9790;</span>
+        <span id="theme-label">Dark</span>
+      </button>
+      <div class="export-wrap">
+        <button
+          id="btn-export"
+          type="button"
+          title="Export diagram (E)"
+          aria-label="Export diagram"
+          aria-haspopup="menu"
+          aria-expanded="false"
+          aria-controls="export-menu"
+        >
+          Export <span aria-hidden="true">&#9662;</span>
+        </button>
+        <div class="export-menu" id="export-menu" role="menu" aria-label="Export">
+          <button data-action="copy" type="button" role="menuitem" tabindex="-1">
+            Copy to clipboard <span class="hint">PNG</span>
+          </button>
+          <hr role="separator" />
+          <button data-format="png" type="button" role="menuitem" tabindex="-1">Download PNG</button>
+          <button data-format="jpeg" type="button" role="menuitem" tabindex="-1">Download JPEG</button>
+          <button data-format="webp" type="button" role="menuitem" tabindex="-1">Download WebP</button>
+          <hr role="separator" />
+          <button data-format="svg" type="button" role="menuitem" tabindex="-1">
+            Download SVG <span class="hint">vector</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="container">
+      <!-- Header -->
+      <div class="header">
+        <div class="header-row">
+          <div class="pulse-dot"></div>
+          <h1>WebChat Runtime Lifecycle</h1>
+        </div>
+        <p class="subtitle">Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect</p>
+      </div>
+
+      <!-- Main Diagram -->
+      <div class="diagram-container">
+        <svg viewBox="0 0 720 1396" role="img" aria-label="WebChat Runtime Lifecycle — Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect (workflow diagram)">
+        <!-- Definitions -->
+        <defs>
+          <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-default" />
+          </marker>
+          <marker id="arrowhead-emphasis" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-emphasis" />
+          </marker>
+          <marker id="arrowhead-security" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-security" />
+          </marker>
+          <marker id="arrowhead-dashed" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+            <polygon points="0 0, 10 3.5, 0 7" class="m-dashed" />
+          </marker>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" class="c-grid" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+
+        <!-- Background Grid -->
+        <rect width="100%" height="100%" fill="url(#grid)" />
+
+        <!-- Swimlanes -->
+        <rect x="40" y="52" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="74" class="t-dim" font-size="10" font-weight="600">01 / Content Tab</text>
+
+        <rect x="40" y="176" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="198" class="t-dim" font-size="10" font-weight="600">02 / Background Coordinator</text>
+
+        <rect x="40" y="300" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="322" class="t-dim" font-size="10" font-weight="600">03 / Shared Runtime Host</text>
+
+        <rect x="40" y="424" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="446" class="t-dim" font-size="10" font-weight="600">04 / Rooms + Runtime Data</text>
+
+        <rect x="40" y="548" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <rect x="46" y="554" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
+        <text x="54" y="570" class="t-security" font-size="10" font-weight="600">EX / Wake: Same Host</text>
+
+        <rect x="40" y="672" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <rect x="46" y="678" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
+        <text x="54" y="694" class="t-security" font-size="10" font-weight="600">EX / Wake: Rebuilt Host</text>
+
+        <rect x="40" y="796" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="818" class="t-dim" font-size="10" font-weight="600">07 / AppButton Refresh</text>
+
+        <rect x="40" y="920" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <rect x="46" y="926" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
+        <text x="54" y="942" class="t-security" font-size="10" font-weight="600">EX / Refresh No-op / Hold</text>
+
+        <rect x="40" y="1044" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="1066" class="t-dim" font-size="10" font-weight="600">09 / BFCache Suspend / Restore</text>
+
+        <rect x="40" y="1168" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
+        <text x="54" y="1190" class="t-dim" font-size="10" font-weight="600">10 / Terminal Page Release</text>
+
+        <!-- Phase headers -->
+        <line x1="42" y1="35" x2="134" y2="35" class="a-default" stroke-width="1.1"/>
+        <rect x="42" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="88" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Inject</text>
+        <line x1="174" y1="35" x2="266" y2="35" class="a-default" stroke-width="1.1"/>
+        <rect x="174" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="220" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Prepare</text>
+        <line x1="254" y1="35" x2="346" y2="35" class="a-default" stroke-width="1.1"/>
+        <rect x="254" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="300" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Register</text>
+        <line x1="384" y1="35" x2="476" y2="35" class="a-default" stroke-width="1.1"/>
+        <rect x="384" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="430" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Host</text>
+        <line x1="454" y1="35" x2="546" y2="35" class="a-default" stroke-width="1.1"/>
+        <rect x="454" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="500" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Attach / Join</text>
+        <line x1="579" y1="35" x2="671" y2="35" class="a-emphasis" stroke-width="1.1"/>
+        <rect x="579" y="27" width="92" height="16" rx="4" class="c-mask"/>
+        <text x="625" y="39" class="t-backend" font-size="8" font-weight="600" text-anchor="middle">Active / Result</text>
+
+        <!-- Workflow groups -->
+
+
+        <!-- Edge paths -->
+        <path d="M 134 119 L 195 119" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 245 119 L 275 119" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 300 145 L 300 166 L 300 166 L 300 217" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 346 243 L 400 243" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 430 269 L 430 290 L 430 290 L 430 341" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 454 367 L 482 367" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 500 269 L 500 290 L 500 290 L 500 341" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 518 367 L 579 367" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 500 393 L 500 414 L 500 414 L 500 465" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 546 491 L 579 491" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 625 457 L 625 313 L 625 313 L 625 393" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 625 341 L 625 57 L 625 57 L 625 153" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 134 615 L 174 615" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 266 615 L 384 615" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 476 615 L 579 615" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 134 739 L 254 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 346 739 L 409 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 451 739 L 479 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 521 739 L 579 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 134 863 L 195 863" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
+        <path d="M 245 863 L 275 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 325 863 L 409 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 451 863 L 479 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 521 863 L 579 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 430 889 L 430 910 L 430 910 L 430 961" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 300 889 L 300 910 L 500 910 L 500 961" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 527.5 987 L 579 987" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 134 1111 L 254 1111" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
+        <path d="M 346 1111 L 454 1111" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
+        <path d="M 134 1235 L 254 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 346 1235 L 454 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 546 1235 L 579 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+
+        <!-- Nodes -->
+        <rect x="42" y="93" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="93" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="88" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Content Script</text>
+        <text x="88" y="131" class="t-muted" font-size="8" text-anchor="middle">new pageId</text>
+
+        <rect x="195" y="93" width="50" height="52" rx="6" class="c-mask"/>
+        <rect x="195" y="93" width="50" height="52" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="220" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Local</text>
+        <text x="220" y="131" class="t-muted" font-size="8" text-anchor="middle">I/O</text>
+
+        <rect x="275" y="93" width="50" height="52" rx="6" class="c-mask"/>
+        <rect x="275" y="93" width="50" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="300" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease</text>
+        <text x="300" y="131" class="t-muted" font-size="8" text-anchor="middle">init</text>
+
+        <rect x="579" y="85" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="579" y="85" width="92" height="68" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="625" y="106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Tab Projection</text>
+        <text x="625" y="123" class="t-muted" font-size="8" text-anchor="middle">tab state</text>
+        <text x="625" y="141" class="t-frontend" font-size="7" text-anchor="middle">page-local</text>
+
+        <rect x="254" y="217" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="254" y="217" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="300" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">registerPage</text>
+        <text x="300" y="255" class="t-muted" font-size="8" text-anchor="middle">tab + URL</text>
+
+        <rect x="400" y="217" width="60" height="52" rx="6" class="c-mask"/>
+        <rect x="400" y="217" width="60" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="430" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Probe</text>
+        <text x="430" y="255" class="t-muted" font-size="8" text-anchor="middle">hostId</text>
+
+        <rect x="470" y="217" width="60" height="52" rx="6" class="c-mask"/>
+        <rect x="470" y="217" width="60" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="500" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Attach</text>
+        <text x="500" y="255" class="t-muted" font-size="8" text-anchor="middle">binding</text>
+
+        <rect x="406" y="341" width="48" height="52" rx="6" class="c-mask"/>
+        <rect x="406" y="341" width="48" height="52" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="430" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Runtime</text>
+        <text x="430" y="379" class="t-muted" font-size="8" text-anchor="middle">host</text>
+
+        <rect x="482" y="341" width="36" height="52" rx="6" class="c-mask"/>
+        <rect x="482" y="341" width="36" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="500" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease</text>
+        <text x="500" y="379" class="t-muted" font-size="8" text-anchor="middle">IDs</text>
+
+        <rect x="579" y="341" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="579" y="341" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="625" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">PagePort</text>
+        <text x="625" y="379" class="t-muted" font-size="8" text-anchor="middle">callbacks</text>
+
+        <rect x="454" y="465" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="454" y="465" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="500" y="486" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Join Rooms</text>
+        <text x="500" y="503" class="t-muted" font-size="8" text-anchor="middle">10s deadline</text>
+
+        <rect x="579" y="457" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="579" y="457" width="92" height="68" rx="6" class="c-database" stroke-width="1.5"/>
+        <text x="625" y="478" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Room State</text>
+        <text x="625" y="495" class="t-muted" font-size="8" text-anchor="middle">Chat / World</text>
+        <text x="625" y="513" class="t-database" font-size="7" text-anchor="middle">Artico owner per room</text>
+
+        <rect x="42" y="589" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="589" width="92" height="52" rx="6" class="c-external" stroke-width="1.5"/>
+        <text x="88" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">System Sleep</text>
+        <text x="88" y="627" class="t-muted" font-size="8" text-anchor="middle">timers pause</text>
+
+        <rect x="174" y="589" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="174" y="589" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="220" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Resume Checks</text>
+        <text x="220" y="627" class="t-muted" font-size="8" text-anchor="middle">same host</text>
+
+        <rect x="384" y="589" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="384" y="589" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="430" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease Healthy</text>
+        <text x="430" y="627" class="t-muted" font-size="8" text-anchor="middle">no replay</text>
+
+        <rect x="579" y="581" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="579" y="581" width="92" height="68" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="625" y="602" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Counts Diverge</text>
+        <text x="625" y="619" class="t-muted" font-size="8" text-anchor="middle">lost callback</text>
+        <text x="625" y="637" class="t-security" font-size="7" text-anchor="middle">confirmed gap</text>
+
+        <rect x="42" y="713" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="713" width="92" height="52" rx="6" class="c-external" stroke-width="1.5"/>
+        <text x="88" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Runtime Lost</text>
+        <text x="88" y="751" class="t-muted" font-size="8" text-anchor="middle">replaced</text>
+
+        <rect x="254" y="713" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="254" y="713" width="92" height="52" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="300" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">New Runtime</text>
+        <text x="300" y="751" class="t-muted" font-size="8" text-anchor="middle">generation +1</text>
+
+        <rect x="409" y="713" width="42" height="52" rx="6" class="c-mask"/>
+        <rect x="409" y="713" width="42" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="430" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Tabs</text>
+        <text x="430" y="751" class="t-muted" font-size="8" text-anchor="middle">pageIds</text>
+
+        <rect x="479" y="713" width="42" height="52" rx="6" class="c-mask"/>
+        <rect x="479" y="713" width="42" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="500" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Stale</text>
+        <text x="500" y="751" class="t-muted" font-size="8" text-anchor="middle">join</text>
+
+        <rect x="579" y="705" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="579" y="705" width="92" height="68" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="625" y="726" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No Rooms</text>
+        <text x="625" y="743" class="t-muted" font-size="8" text-anchor="middle">empty host</text>
+        <text x="625" y="761" class="t-security" font-size="7" text-anchor="middle">primary suspect</text>
+
+        <rect x="42" y="837" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="837" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="88" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Refresh Click</text>
+        <text x="88" y="875" class="t-muted" font-size="8" text-anchor="middle">reconnect</text>
+
+        <rect x="195" y="837" width="50" height="52" rx="6" class="c-mask"/>
+        <rect x="195" y="837" width="50" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="220" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">World</text>
+        <text x="220" y="875" class="t-muted" font-size="8" text-anchor="middle">async</text>
+
+        <rect x="275" y="837" width="50" height="52" rx="6" class="c-mask"/>
+        <rect x="275" y="837" width="50" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="300" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Gate</text>
+        <text x="300" y="875" class="t-muted" font-size="8" text-anchor="middle">seed?</text>
+
+        <rect x="409" y="837" width="42" height="52" rx="6" class="c-mask"/>
+        <rect x="409" y="837" width="42" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="430" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Reset</text>
+        <text x="430" y="875" class="t-muted" font-size="8" text-anchor="middle">state</text>
+
+        <rect x="479" y="837" width="42" height="52" rx="6" class="c-mask"/>
+        <rect x="479" y="837" width="42" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="500" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Rejoin</text>
+        <text x="500" y="875" class="t-muted" font-size="8" text-anchor="middle">10s</text>
+
+        <rect x="579" y="837" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="579" y="837" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="625" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Commit</text>
+        <text x="625" y="875" class="t-muted" font-size="8" text-anchor="middle">settles</text>
+
+        <rect x="402.5" y="961" width="55" height="52" rx="6" class="c-mask"/>
+        <rect x="402.5" y="961" width="55" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="430" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Hold</text>
+        <text x="430" y="999" class="t-muted" font-size="8" text-anchor="middle">cancel</text>
+
+        <rect x="472.5" y="961" width="55" height="52" rx="6" class="c-mask"/>
+        <rect x="472.5" y="961" width="55" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="500" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No-op</text>
+        <text x="500" y="999" class="t-muted" font-size="8" text-anchor="middle">no seed</text>
+
+        <rect x="579" y="961" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="579" y="961" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="625" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No Peer</text>
+        <text x="625" y="999" class="t-muted" font-size="8" text-anchor="middle">loading ends</text>
+
+        <rect x="42" y="1085" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="1085" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="88" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">pagehide</text>
+        <text x="88" y="1123" class="t-muted" font-size="8" text-anchor="middle">stop lease</text>
+
+        <rect x="254" y="1085" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="254" y="1085" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="300" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease Retained</text>
+        <text x="300" y="1123" class="t-muted" font-size="8" text-anchor="middle">same pageId</text>
+
+        <rect x="454" y="1085" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="454" y="1085" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="500" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">pageshow</text>
+        <text x="500" y="1123" class="t-muted" font-size="8" text-anchor="middle">re-register</text>
+
+        <rect x="42" y="1209" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="42" y="1209" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="88" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Terminal Exit</text>
+        <text x="88" y="1247" class="t-muted" font-size="8" text-anchor="middle">navigate</text>
+
+        <rect x="254" y="1209" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="254" y="1209" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="300" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">detachPage</text>
+        <text x="300" y="1247" class="t-muted" font-size="8" text-anchor="middle">drop pageId</text>
+
+        <rect x="454" y="1209" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="454" y="1209" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="500" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">5s Grace</text>
+        <text x="500" y="1247" class="t-muted" font-size="8" text-anchor="middle">wait return</text>
+
+        <rect x="579" y="1209" width="92" height="52" rx="6" class="c-mask"/>
+        <rect x="579" y="1209" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="625" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Release Domain</text>
+        <text x="625" y="1247" class="t-muted" font-size="8" text-anchor="middle">leave + clear</text>
+
+        <!-- Edge labels -->
+
+
+
+
+
+
+
+
+
+
+
+        <rect x="603.2" y="37" width="43.6" height="14" rx="3" class="c-mask"/>
+        <text x="625" y="47" class="t-backend" font-size="8" text-anchor="middle">project</text>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <!-- Legend -->
+        <text x="175" y="1296" class="t-primary" font-size="10" font-weight="600">Legend</text>
+        <rect x="175" y="1308" width="14" height="9" rx="2" class="c-frontend" stroke-width="1"/>
+        <text x="195" y="1316" class="t-muted" font-size="7">User UI</text>
+        <rect x="260" y="1308" width="14" height="9" rx="2" class="c-backend" stroke-width="1"/>
+        <text x="280" y="1316" class="t-muted" font-size="7">Agent logic</text>
+        <rect x="370" y="1308" width="14" height="9" rx="2" class="c-security" stroke-width="1"/>
+        <text x="390" y="1316" class="t-muted" font-size="7">Policy</text>
+        <rect x="455" y="1308" width="14" height="9" rx="2" class="c-messagebus" stroke-width="1"/>
+        <text x="475" y="1316" class="t-muted" font-size="7">Tool action</text>
+        <rect x="565" y="1308" width="14" height="9" rx="2" class="c-database" stroke-width="1"/>
+        <text x="585" y="1316" class="t-muted" font-size="7">Context / trace</text>
+      </svg>
+      </div>
+
+      <!-- Info Cards -->
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot cyan"></div>
+          <h3>Ownership</h3>
+        </div>
+        <ul>
+          <li>&bull; One pageId and UI projection per content document</li>
+          <li>&bull; One Coordinator persists tab-to-page bindings</li>
+          <li>&bull; One shared Runtime owns Chat and World peers</li>
+          <li>&bull; Chat and World counts are projected separately in every tab</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Sleep/Wake Gaps</h3>
+        </div>
+        <ul>
+          <li>&bull; Same host: callback loss has no delivery acknowledgement or replay</li>
+          <li>&bull; New host: rebuildTabs restores page leases, not room aggregates</li>
+          <li>&bull; Content JoinStatus survives while the new Runtime has no rooms</li>
+          <li>&bull; That mismatch explains divergent counts and an empty Runtime</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot emerald"></div>
+          <h3>Refresh Semantics</h3>
+        </div>
+        <ul>
+          <li>&bull; The button awaits only the Chat domain operation</li>
+          <li>&bull; World replacement runs independently</li>
+          <li>&bull; A missing Runtime domain and seed produces a successful no-op</li>
+          <li>&bull; A real replacement join has a ten-second outer deadline</li>
+        </ul>
+      </div>
+    </div>
+
+      <!-- Footer -->
+      <p class="footer">Workflow diagram &bull; Built with Archify<span class="no-print"> &bull; Press <kbd>T</kbd> for theme and <kbd>E</kbd> for export</span></p>
+    </div>
+
+    <script>
+      /* ============================================================
+       Theme toggle — persists to localStorage, respects system pref
+       ============================================================ */
+      var Archify = {}
+
+      Archify.theme = (function () {
+        var STORAGE_KEY = 'archify-theme'
+        var html = document.documentElement
+        var btn = document.getElementById('btn-theme')
+        var icon = document.getElementById('theme-icon')
+        var label = document.getElementById('theme-label')
+
+        // localStorage can throw (blocked cookies, sandboxed iframes); the whole
+        // script element dies on an uncaught error, so guard every access.
+        function readStored() {
+          try {
+            return localStorage.getItem(STORAGE_KEY)
+          } catch (_) {
+            return null
+          }
+        }
+        function writeStored(value) {
+          try {
+            localStorage.setItem(STORAGE_KEY, value)
+          } catch (_) {}
+        }
+        function urlOverride() {
+          // URL param wins (useful for deterministic screenshots / share links)
+          try {
+            var param = new URLSearchParams(window.location.search).get('theme')
+            if (param === 'light' || param === 'dark') return param
+          } catch (_) {}
+          return null
+        }
+
+        function resolveInitial() {
+          var fromUrl = urlOverride()
+          if (fromUrl) return fromUrl
+          var saved = readStored()
+          if (saved === 'light' || saved === 'dark') return saved
+          return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+        }
+
+        function apply(theme) {
+          html.setAttribute('data-theme', theme)
+          icon.textContent = theme === 'dark' ? '\u263E' : '\u263C'
+          label.textContent = theme === 'dark' ? 'Dark' : 'Light'
+          btn.setAttribute('aria-pressed', theme === 'light' ? 'true' : 'false')
+        }
+
+        function toggle() {
+          var next = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'
+          apply(next)
+          writeStored(next)
+        }
+
+        apply(resolveInitial())
+        btn.addEventListener('click', toggle)
+
+        // Follow live OS theme changes while the user has no explicit preference.
+        try {
+          var media = window.matchMedia('(prefers-color-scheme: light)')
+          var onChange = function (e) {
+            var saved = readStored()
+            if (urlOverride() || saved === 'light' || saved === 'dark') return
+            apply(e.matches ? 'light' : 'dark')
+          }
+          if (media.addEventListener) media.addEventListener('change', onChange)
+          else if (media.addListener) media.addListener(onChange)
+        } catch (_) {}
+
+        return { toggle: toggle }
+      })()
+
+      /* ============================================================
+       Export — PNG / JPEG / WebP / SVG (download) and Copy PNG (clipboard)
+
+       Raster exports are always rendered at 4x source resolution for
+       maximum sharpness. The trick: we set the serialized SVG's
+       `width`/`height` to viewBox * 4 so the browser rasterizes the
+       vectors at that resolution natively. drawImage then draws at
+       the image's natural size (no upscaling = no blur).
+
+       JPEG/WebP paint the current theme's background explicitly since
+       those formats have no alpha channel.
+       ============================================================ */
+      ;(function () {
+        var RASTER_SCALE = 4
+
+        function diagramFilename() {
+          var title = (document.title || 'diagram')
+            .replace(/\s+Architecture(\s+Diagram)?$/i, '')
+            .replace(/\s+Diagram$/i, '')
+            .trim()
+          return (
+            title
+              .replace(/[^a-z0-9_\-]+/gi, '-')
+              .toLowerCase()
+              .replace(/^-+|-+$/g, '') || 'diagram'
+          )
+        }
+
+        function currentBg() {
+          return getComputedStyle(document.body).backgroundColor || '#ffffff'
+        }
+
+        /**
+         * Serialize the main SVG into a standalone document.
+         *
+         * Two modes:
+         * - Default (opts.autoTheme=false) — locks the serialized SVG to the
+         *   viewer's current theme. Used by the raster pipeline
+         *   (PNG/JPEG/WebP/clipboard) because canvas rasterization needs
+         *   deterministic colors; a raster cannot react to
+         *   prefers-color-scheme after encoding.
+         * - autoTheme=true — emits BOTH dark and light variable sets plus a
+         *   `@media (prefers-color-scheme)` rule so the resulting SVG
+         *   self-themes when embedded in GitHub READMEs or other hosts that
+         *   expose a color scheme. Used for "Download SVG".
+         */
+        function serializeSvg(scale, opts) {
+          // scale: integer multiplier for intrinsic SVG pixel dimensions used by
+          // the raster path. Defaults to 1 (natural size) for SVG download.
+          scale = scale || 1
+          opts = opts || {}
+          var autoTheme = opts.autoTheme === true
+
+          var svg = document.querySelector('.diagram-container svg')
+          var clone = svg.cloneNode(true)
+
+          var vb = svg.viewBox.baseVal
+          // Scale width/height so the browser rasterizes the vectors at target
+          // resolution directly. viewBox stays unchanged so coordinates don't
+          // shift. This is the key to sharp rasters — do NOT scale later via
+          // canvas upscaling.
+          clone.setAttribute('width', vb.width * scale)
+          clone.setAttribute('height', vb.height * scale)
+          clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+          // Only the SVG-relevant rules: semantic classes, markers, and the
+          // theme variable blocks. Toolbar/cards/print CSS can never apply
+          // inside a standalone SVG and would only bloat the export.
+          var hostStyle = (function () {
+            var out = []
+            Array.prototype.forEach.call(document.styleSheets, function (sheet) {
+              var rules
+              try {
+                rules = sheet.cssRules
+              } catch (_) {
+                return
+              } // cross-origin
+              if (!rules) return
+              Array.prototype.forEach.call(rules, function (rule) {
+                if (rule.type !== 1) return // plain style rules only
+                var sel = rule.selectorText || ''
+                if (/(^|,)\s*(svg|:root|\[data-theme|\.c-|\.t-|\.a-|\.m-)/.test(sel)) {
+                  out.push(rule.cssText)
+                }
+              })
+            })
+            return out.join('\n')
+          })()
+
+          // Derive the variable list from the stylesheet so newly added theme
+          // variables can never be missed by the export pipeline again
+          // (--lane-fill/--lane-stroke once were).
+          var varNames = (function () {
+            var seen = {}
+            var names = []
+            ;(hostStyle.match(/--[a-zA-Z0-9-]+(?=\s*:)/g) || []).forEach(function (n) {
+              if (!seen[n]) {
+                seen[n] = true
+                names.push(n)
+              }
+            })
+            return names
+          })()
+
+          // Resolve the full variable set for a given data-theme via an
+          // off-DOM probe, independent of what the viewer is currently set to.
+          function resolveVars(themeAttr) {
+            var probe = document.createElement('div')
+            probe.setAttribute('data-theme', themeAttr)
+            probe.style.cssText = 'position:absolute;width:0;height:0;visibility:hidden;'
+            document.body.appendChild(probe)
+            try {
+              var c = getComputedStyle(probe)
+              return varNames
+                .map(function (n) {
+                  return n + ': ' + c.getPropertyValue(n).trim() + ';'
+                })
+                .join(' ')
+            } finally {
+              document.body.removeChild(probe)
+            }
+          }
+
+          // Prepend a local()-only @font-face block for each weight so that the
+          // sandboxed image-rendering context used during PNG/JPEG/WebP export
+          // can find JetBrains Mono if the user has it installed locally, and
+          // falls through cleanly to the monospace stack otherwise. The usual
+          // Google-Fonts <link> in the host document is unreachable from the
+          // serialized SVG, so url()-sourced faces would just hang.
+          var fontFallback = [400, 500, 600, 700]
+            .map(function (w) {
+              return (
+                "@font-face { font-family: 'JetBrains Mono'; font-weight: " +
+                w +
+                "; src: local('JetBrains Mono'), local('JetBrainsMono-Regular'); }"
+              )
+            })
+            .join('\n')
+
+          var style = document.createElementNS('http://www.w3.org/2000/svg', 'style')
+          var bgRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+          bgRect.setAttribute('width', '100%')
+          bgRect.setAttribute('height', '100%')
+
+          if (autoTheme) {
+            // Dual-theme SVG. Dark is the default (so hosts without
+            // prefers-color-scheme still render), light swaps in via media
+            // query, and svg[data-theme="..."] still lets downstream
+            // consumers force a specific theme.
+            var darkVars = resolveVars('dark')
+            var lightVars = resolveVars('light')
+
+            style.textContent =
+              fontFallback +
+              '\n' +
+              "svg { font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono CJK SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', monospace; }\n" +
+              hostStyle +
+              '\n' +
+              ':root, svg { ' +
+              darkVars +
+              ' }\n' +
+              '@media (prefers-color-scheme: light) { :root, svg { ' +
+              lightVars +
+              ' } }\n' +
+              'svg[data-theme="light"] { ' +
+              lightVars +
+              ' }\n' +
+              'svg[data-theme="dark"] { ' +
+              darkVars +
+              ' }\n' +
+              'rect.c-bg-rect { fill: var(--bg); }\n'
+
+            // Don't lock the serialized SVG to the viewer's current theme.
+            clone.removeAttribute('data-theme')
+            // Background follows the CSS variable, not a fixed color, so it
+            // swaps with the media query.
+            bgRect.setAttribute('class', 'c-bg-rect')
+          } else {
+            // Raster path: lock to the viewer's current theme.
+            var theme = document.documentElement.getAttribute('data-theme') || 'dark'
+            var themeHost = document.querySelector('[data-theme="' + theme + '"]') || document.documentElement
+            var computed = getComputedStyle(themeHost)
+            var vars = varNames
+              .map(function (n) {
+                return n + ': ' + computed.getPropertyValue(n).trim() + ';'
+              })
+              .join(' ')
+
+            // IMPORTANT: inject the resolved variables AFTER hostStyle,
+            // otherwise hostStyle's ":root, [data-theme=\"dark\"] { ... }" rule
+            // overrides our chosen theme via later-in-cascade equal-specificity.
+            // Keep this order.
+            style.textContent =
+              fontFallback +
+              '\n' +
+              "svg { font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono CJK SC', 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', monospace; }\n" +
+              hostStyle +
+              '\n' +
+              ':root, svg { ' +
+              vars +
+              ' }\n'
+
+            bgRect.setAttribute('fill', computed.getPropertyValue('--bg').trim() || '#ffffff')
+          }
+
+          clone.insertBefore(style, clone.firstChild)
+          clone.insertBefore(bgRect, style.nextSibling)
+
+          return {
+            svgString: new XMLSerializer().serializeToString(clone),
+            width: vb.width * scale,
+            height: vb.height * scale
+          }
+        }
+
+        function download(blob, filename) {
+          var url = URL.createObjectURL(blob)
+          var a = document.createElement('a')
+          a.href = url
+          a.download = filename
+          document.body.appendChild(a)
+          a.click()
+          a.remove()
+          setTimeout(function () {
+            URL.revokeObjectURL(url)
+          }, 1000)
+        }
+
+        // Conservative upper bound on total canvas pixels. Older Safari on iOS
+        // silently produces a blank canvas above ~16 Mpx; Chrome / Firefox /
+        // desktop Safari are far higher but start failing on memory-constrained
+        // devices. We pick the largest integer scale in {4,3,2,1} whose target
+        // pixel count fits under this cap.
+        var MAX_CANVAS_PIXELS = 16 * 1024 * 1024
+
+        function pickSafeScale(vbW, vbH) {
+          for (var s = RASTER_SCALE; s >= 1; s--) {
+            if (vbW * s * vbH * s <= MAX_CANVAS_PIXELS) return s
+          }
+          return 1
+        }
+
+        function rasterize(format) {
+          // Serialize at a safe scale (RASTER_SCALE=4 by default, reduced if the
+          // resulting canvas would exceed MAX_CANVAS_PIXELS). The SVG itself is
+          // rasterized at target resolution natively; drawImage draws at natural
+          // size — no upsampling blur.
+          var svg = document.querySelector('.diagram-container svg')
+          var vb = svg.viewBox.baseVal
+          var scale = pickSafeScale(vb.width, vb.height)
+          var data = serializeSvg(scale)
+          var svgBlob = new Blob([data.svgString], { type: 'image/svg+xml;charset=utf-8' })
+          var svgUrl = URL.createObjectURL(svgBlob)
+
+          return new Promise(function (resolve, reject) {
+            var img = new Image()
+            img.onload = function () {
+              var canvas = document.createElement('canvas')
+              canvas.width = data.width
+              canvas.height = data.height
+              var ctx = canvas.getContext('2d')
+              if (format === 'jpeg') {
+                ctx.fillStyle = currentBg()
+                ctx.fillRect(0, 0, canvas.width, canvas.height)
+              }
+              // Draw at natural size — SVG was already rasterized at target res.
+              ctx.drawImage(img, 0, 0)
+              URL.revokeObjectURL(svgUrl)
+              var mime = format === 'jpeg' ? 'image/jpeg' : format === 'webp' ? 'image/webp' : 'image/png'
+              var quality = format === 'png' ? undefined : 0.95
+              canvas.toBlob(
+                function (blob) {
+                  if (!blob) reject(new Error('toBlob returned null for ' + format))
+                  else resolve(blob)
+                },
+                mime,
+                quality
+              )
+            }
+            img.onerror = function (e) {
+              URL.revokeObjectURL(svgUrl)
+              reject(e)
+            }
+            img.src = svgUrl
+          })
+        }
+
+        var menu = document.getElementById('export-menu')
+        var btn = document.getElementById('btn-export')
+        var items = function () {
+          return Array.prototype.slice.call(menu.querySelectorAll('button[role="menuitem"]'))
+        }
+
+        // ---- Clipboard support ----------------------------------------------
+        function canCopyImage() {
+          return (
+            typeof ClipboardItem !== 'undefined' &&
+            navigator.clipboard &&
+            typeof navigator.clipboard.write === 'function'
+          )
+        }
+
+        // ---- Raster format detection ----------------------------------------
+        // canvas.toBlob('image/webp') silently returns a PNG on browsers without
+        // WebP encoding (older Safari), so detect explicitly.
+        function supports(format) {
+          if (format === 'svg' || format === 'png') return true
+          var mime = format === 'jpeg' ? 'image/jpeg' : 'image/webp'
+          try {
+            var c = document.createElement('canvas')
+            c.width = c.height = 2
+            return c.toDataURL(mime).indexOf('data:' + mime) === 0
+          } catch (_) {
+            return false
+          }
+        }
+
+        // Gray out unsupported items.
+        items().forEach(function (it) {
+          if (it.dataset.format && !supports(it.dataset.format)) {
+            it.disabled = true
+            it.title = 'Not supported by this browser'
+            it.style.opacity = '0.5'
+          }
+          if (it.dataset.action === 'copy' && !canCopyImage()) {
+            it.disabled = true
+            it.title = 'Clipboard image write not supported by this browser'
+            it.style.opacity = '0.5'
+          }
+        })
+
+        // ---- Toast ----------------------------------------------------------
+        // A live region only announces CHANGES to an existing node, so the toast
+        // element is created once up front and updated in place.
+        var toastEl = document.createElement('div')
+        toastEl.className = 'archify-toast'
+        toastEl.setAttribute('role', 'status')
+        document.body.appendChild(toastEl)
+        var toastTimer = null
+
+        function toast(msg) {
+          toastEl.textContent = ''
+          requestAnimationFrame(function () {
+            toastEl.textContent = msg
+            toastEl.classList.add('show')
+          })
+          clearTimeout(toastTimer)
+          toastTimer = setTimeout(function () {
+            toastEl.classList.remove('show')
+          }, 1500)
+        }
+
+        function open(focusLast) {
+          menu.classList.add('open')
+          btn.setAttribute('aria-expanded', 'true')
+          var available = items().filter(function (i) {
+            return !i.disabled
+          })
+          var target = focusLast ? available[available.length - 1] : available[0]
+          if (target) target.focus()
+        }
+        function close(focusTrigger) {
+          menu.classList.remove('open')
+          btn.setAttribute('aria-expanded', 'false')
+          if (focusTrigger) btn.focus()
+        }
+        function isOpen() {
+          return menu.classList.contains('open')
+        }
+
+        btn.addEventListener('click', function (e) {
+          e.stopPropagation()
+          if (isOpen()) close(false)
+          else open()
+        })
+        // APG menu-button pattern: ArrowDown/ArrowUp on the trigger opens the menu.
+        btn.addEventListener('keydown', function (e) {
+          if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            e.preventDefault()
+            if (!isOpen()) open(e.key === 'ArrowUp')
+          }
+        })
+        document.addEventListener('click', function (e) {
+          if (!menu.contains(e.target) && e.target !== btn) close(false)
+        })
+
+        // Keyboard navigation inside the menu.
+        //   Menu items: Up/Down, Home/End.
+        //   Esc closes + returns focus to trigger; Tab closes.
+        menu.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') {
+            e.preventDefault()
+            close(true)
+            return
+          }
+          if (e.key === 'Tab') {
+            close(false)
+            return
+          }
+
+          var available = items().filter(function (i) {
+            return !i.disabled
+          })
+          var current = available.indexOf(document.activeElement)
+          switch (e.key) {
+            case 'ArrowDown':
+              e.preventDefault()
+              if (available.length) available[(current + 1 + available.length) % available.length].focus()
+              break
+            case 'ArrowUp':
+              e.preventDefault()
+              if (available.length) available[(current - 1 + available.length) % available.length].focus()
+              break
+            case 'Home':
+              e.preventDefault()
+              if (available[0]) available[0].focus()
+              break
+            case 'End':
+              e.preventDefault()
+              if (available.length) available[available.length - 1].focus()
+              break
+          }
+        })
+
+        function runExport(format) {
+          var base = diagramFilename()
+          close(true)
+          return (
+            format === 'svg'
+              ? Promise.resolve(serializeSvg(1, { autoTheme: true })).then(function (d) {
+                  download(new Blob([d.svgString], { type: 'image/svg+xml;charset=utf-8' }), base + '.svg')
+                })
+              : rasterize(format).then(function (blob) {
+                  download(blob, base + '.' + format)
+                })
+          ).catch(function (err) {
+            console.error(err)
+            alert('Export failed: ' + (err && err.message ? err.message : format))
+          })
+        }
+
+        function runCopy() {
+          close(true)
+          if (!canCopyImage()) {
+            alert('Clipboard image write not supported in this browser.')
+            return
+          }
+          // WebKit requires ClipboardItem to be constructed synchronously inside
+          // the user gesture — pass the pending Promise<Blob> as the item value.
+          // Browsers that reject promise values throw synchronously; fall back
+          // to awaiting the blob first (works in Chromium/Firefox).
+          var blobPromise = rasterize('png')
+          var writePromise
+          try {
+            writePromise = navigator.clipboard.write([new ClipboardItem({ 'image/png': blobPromise })])
+          } catch (_) {
+            writePromise = blobPromise.then(function (blob) {
+              return navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+            })
+          }
+          return writePromise
+            .then(function () {
+              toast('Copied PNG to clipboard')
+            })
+            .catch(function (err) {
+              console.error(err)
+              alert('Copy failed: ' + (err && err.message ? err.message : 'unknown'))
+            })
+        }
+
+        menu.addEventListener('click', function (e) {
+          var copyBtn = e.target.closest('button[data-action="copy"]')
+          if (copyBtn && !copyBtn.disabled) {
+            runCopy()
+            return
+          }
+
+          var formatBtn = e.target.closest('button[data-format]')
+          if (formatBtn && !formatBtn.disabled) {
+            runExport(formatBtn.dataset.format)
+          }
+        })
+
+        Archify.exportMenu = { open: open, close: close, isOpen: isOpen, run: runExport }
+
+        // Auto-open on page load for demo/screenshot purposes: ?openExport=1
+        // Wait for fonts (so the menu doesn't flash before typography lands)
+        // and paint before opening. Fallback timeout for browsers without the
+        // Font Loading API.
+        try {
+          if (new URLSearchParams(window.location.search).get('openExport') === '1') {
+            var openWhenReady = function () {
+              requestAnimationFrame(function () {
+                requestAnimationFrame(open)
+              })
+            }
+            if (document.fonts && document.fonts.ready) {
+              document.fonts.ready.then(openWhenReady)
+            } else {
+              setTimeout(openWhenReady, 200)
+            }
+          }
+        } catch (_) {}
+      })()
+
+      /* ============================================================
+       Global keyboard shortcuts
+         T -> toggle theme
+         E -> open export menu
+       Ignored when focus is inside an input/textarea/contenteditable.
+       ============================================================ */
+      document.addEventListener('keydown', function (e) {
+        if (e.metaKey || e.ctrlKey || e.altKey) return
+        var t = e.target
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return
+        if (e.key === 't' || e.key === 'T') {
+          e.preventDefault()
+          Archify.theme.toggle()
+        } else if (e.key === 'e' || e.key === 'E') {
+          e.preventDefault()
+          if (!Archify.exportMenu.isOpen()) Archify.exportMenu.open()
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/docs/architecture/webchat-runtime-lifecycle.html
+++ b/docs/architecture/webchat-runtime-lifecycle.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content="archify 2.11.0" />
-    <title>WebChat Runtime Lifecycle Diagram</title>
+    <title>WebChat Backend Action Wake Gateway Diagram</title>
     <script>
       // Resolve the theme before first paint so light-preference users don't
       // see a dark flash. The toolbar script below re-applies with UI state.
@@ -712,14 +712,14 @@
       <div class="header">
         <div class="header-row">
           <div class="pulse-dot"></div>
-          <h1>WebChat Runtime Lifecycle</h1>
+          <h1>WebChat Backend Action Wake Gateway</h1>
         </div>
-        <p class="subtitle">Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect</p>
+        <p class="subtitle">Every backend-bound action crosses Background start/reuse and Offscreen probe/rebuild</p>
       </div>
 
       <!-- Main Diagram -->
       <div class="diagram-container">
-        <svg viewBox="0 0 720 1396" role="img" aria-label="WebChat Runtime Lifecycle — Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect (workflow diagram)">
+        <svg viewBox="0 0 720 776" role="img" aria-label="WebChat Backend Action Wake Gateway — Every backend-bound action crosses Background start/reuse and Offscreen probe/rebuild (workflow diagram)">
         <!-- Definitions -->
         <defs>
           <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
@@ -744,332 +744,119 @@
 
         <!-- Swimlanes -->
         <rect x="40" y="52" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="74" class="t-dim" font-size="10" font-weight="600">01 / Content Tab</text>
+        <text x="54" y="74" class="t-dim" font-size="10" font-weight="600">01 / Content Caller</text>
 
         <rect x="40" y="176" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="198" class="t-dim" font-size="10" font-weight="600">02 / Background Coordinator</text>
+        <text x="54" y="198" class="t-dim" font-size="10" font-weight="600">02 / Background Gateway</text>
 
         <rect x="40" y="300" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="322" class="t-dim" font-size="10" font-weight="600">03 / Shared Runtime Host</text>
+        <text x="54" y="322" class="t-dim" font-size="10" font-weight="600">03 / Offscreen Alive</text>
 
         <rect x="40" y="424" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="446" class="t-dim" font-size="10" font-weight="600">04 / Rooms + Runtime Data</text>
+        <rect x="46" y="430" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
+        <text x="54" y="446" class="t-security" font-size="10" font-weight="600">EX / Offscreen Missing</text>
 
         <rect x="40" y="548" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
         <rect x="46" y="554" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
-        <text x="54" y="570" class="t-security" font-size="10" font-weight="600">EX / Wake: Same Host</text>
-
-        <rect x="40" y="672" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <rect x="46" y="678" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
-        <text x="54" y="694" class="t-security" font-size="10" font-weight="600">EX / Wake: Rebuilt Host</text>
-
-        <rect x="40" y="796" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="818" class="t-dim" font-size="10" font-weight="600">07 / AppButton Refresh</text>
-
-        <rect x="40" y="920" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <rect x="46" y="926" width="628" height="92" rx="8" class="c-security-group" stroke-width="1"/>
-        <text x="54" y="942" class="t-security" font-size="10" font-weight="600">EX / Refresh No-op / Hold</text>
-
-        <rect x="40" y="1044" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="1066" class="t-dim" font-size="10" font-weight="600">09 / BFCache Suspend / Restore</text>
-
-        <rect x="40" y="1168" width="640" height="104" rx="10" class="c-lane" stroke-width="1"/>
-        <text x="54" y="1190" class="t-dim" font-size="10" font-weight="600">10 / Terminal Page Release</text>
+        <text x="54" y="570" class="t-security" font-size="10" font-weight="600">EX / Current Recovery Gap</text>
 
         <!-- Phase headers -->
         <line x1="42" y1="35" x2="134" y2="35" class="a-default" stroke-width="1.1"/>
         <rect x="42" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="88" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Inject</text>
-        <line x1="174" y1="35" x2="266" y2="35" class="a-default" stroke-width="1.1"/>
-        <rect x="174" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="220" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Prepare</text>
-        <line x1="254" y1="35" x2="346" y2="35" class="a-default" stroke-width="1.1"/>
-        <rect x="254" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="300" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Register</text>
-        <line x1="384" y1="35" x2="476" y2="35" class="a-default" stroke-width="1.1"/>
-        <rect x="384" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="430" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Host</text>
-        <line x1="454" y1="35" x2="546" y2="35" class="a-default" stroke-width="1.1"/>
-        <rect x="454" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="500" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Attach / Join</text>
-        <line x1="579" y1="35" x2="671" y2="35" class="a-emphasis" stroke-width="1.1"/>
-        <rect x="579" y="27" width="92" height="16" rx="4" class="c-mask"/>
-        <text x="625" y="39" class="t-backend" font-size="8" font-weight="600" text-anchor="middle">Active / Result</text>
+        <text x="88" y="39" class="t-muted" font-size="8" font-weight="600" text-anchor="middle">Dispatch</text>
+        <line x1="174" y1="35" x2="346" y2="35" class="a-emphasis" stroke-width="1.1"/>
+        <rect x="174" y="27" width="172" height="16" rx="4" class="c-mask"/>
+        <text x="260" y="39" class="t-backend" font-size="8" font-weight="600" text-anchor="middle">Background</text>
+        <line x1="384" y1="35" x2="671" y2="35" class="a-security" stroke-width="1.1"/>
+        <rect x="384" y="27" width="287" height="16" rx="4" class="c-mask"/>
+        <text x="527.5" y="39" class="t-security" font-size="8" font-weight="600" text-anchor="middle">Offscreen Runtime</text>
 
         <!-- Workflow groups -->
 
 
         <!-- Edge paths -->
-        <path d="M 134 119 L 195 119" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 245 119 L 275 119" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 300 145 L 300 166 L 300 166 L 300 217" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 346 243 L 400 243" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 430 269 L 430 290 L 430 290 L 430 341" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 454 367 L 482 367" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 500 269 L 500 290 L 500 290 L 500 341" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 518 367 L 579 367" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 500 393 L 500 414 L 500 414 L 500 465" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 546 491 L 579 491" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 625 457 L 625 313 L 625 313 L 625 393" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 625 341 L 625 57 L 625 57 L 625 153" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 134 615 L 174 615" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 266 615 L 384 615" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 476 615 L 579 615" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 134 739 L 254 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 346 739 L 409 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 451 739 L 479 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 521 739 L 579 739" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 134 863 L 195 863" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
-        <path d="M 245 863 L 275 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 325 863 L 409 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 451 863 L 479 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 521 863 L 579 863" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
-        <path d="M 430 889 L 430 910 L 430 910 L 430 961" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 300 889 L 300 910 L 500 910 L 500 961" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 527.5 987 L 579 987" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
-        <path d="M 134 1111 L 254 1111" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
-        <path d="M 346 1111 L 454 1111" class="a-dashed" stroke-width="1.4" marker-end="url(#arrowhead-dashed)"/>
-        <path d="M 134 1235 L 254 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 346 1235 L 454 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
-        <path d="M 546 1235 L 579 1235" class="a-default" stroke-width="1.4" marker-end="url(#arrowhead)"/>
+        <path d="M 88 153 L 88 166 L 220 166 L 220 217" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 245 243 L 275 243" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 325 243 L 466 243" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 500 277 L 500 290 L 625 290 L 625 333" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 534 243 L 692 243 L 692 491 L 671 491" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
+        <path d="M 625 333 L 625 57 L 625 57 L 625 153" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 671 491 L 692 491 L 692 119 L 671 119" class="a-emphasis" stroke-width="1.8" marker-end="url(#arrowhead-emphasis)"/>
+        <path d="M 625 525 L 625 538 L 625 538 L 625 581" class="a-security" stroke-width="1.4" marker-end="url(#arrowhead-security)"/>
 
         <!-- Nodes -->
-        <rect x="42" y="93" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="93" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="88" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Content Script</text>
-        <text x="88" y="131" class="t-muted" font-size="8" text-anchor="middle">new pageId</text>
-
-        <rect x="195" y="93" width="50" height="52" rx="6" class="c-mask"/>
-        <rect x="195" y="93" width="50" height="52" rx="6" class="c-database" stroke-width="1.5"/>
-        <text x="220" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Local</text>
-        <text x="220" y="131" class="t-muted" font-size="8" text-anchor="middle">I/O</text>
-
-        <rect x="275" y="93" width="50" height="52" rx="6" class="c-mask"/>
-        <rect x="275" y="93" width="50" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="300" y="114" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease</text>
-        <text x="300" y="131" class="t-muted" font-size="8" text-anchor="middle">init</text>
+        <rect x="42" y="85" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="42" y="85" width="92" height="68" rx="6" class="c-frontend" stroke-width="1.5"/>
+        <text x="88" y="106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Backend Action</text>
+        <text x="88" y="123" class="t-muted" font-size="8" text-anchor="middle">RPC / operation</text>
+        <text x="88" y="141" class="t-frontend" font-size="7" text-anchor="middle">reload / AppButton</text>
 
         <rect x="579" y="85" width="92" height="68" rx="6" class="c-mask"/>
-        <rect x="579" y="85" width="92" height="68" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="625" y="106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Tab Projection</text>
-        <text x="625" y="123" class="t-muted" font-size="8" text-anchor="middle">tab state</text>
-        <text x="625" y="141" class="t-frontend" font-size="7" text-anchor="middle">page-local</text>
+        <rect x="579" y="85" width="92" height="68" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="625" y="106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Resume Action</text>
+        <text x="625" y="123" class="t-muted" font-size="8" text-anchor="middle">original action</text>
+        <text x="625" y="141" class="t-backend" font-size="7" text-anchor="middle">after recovery</text>
 
-        <rect x="254" y="217" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="254" y="217" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="300" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">registerPage</text>
-        <text x="300" y="255" class="t-muted" font-size="8" text-anchor="middle">tab + URL</text>
+        <rect x="195" y="217" width="50" height="52" rx="6" class="c-mask"/>
+        <rect x="195" y="217" width="50" height="52" rx="6" class="c-security" stroke-width="1.5"/>
+        <text x="220" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Active?</text>
+        <text x="220" y="255" class="t-muted" font-size="8" text-anchor="middle">MV3 worker</text>
 
-        <rect x="400" y="217" width="60" height="52" rx="6" class="c-mask"/>
-        <rect x="400" y="217" width="60" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="430" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Probe</text>
-        <text x="430" y="255" class="t-muted" font-size="8" text-anchor="middle">hostId</text>
+        <rect x="275" y="209" width="50" height="68" rx="6" class="c-mask"/>
+        <rect x="275" y="209" width="50" height="68" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="300" y="230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Wake</text>
+        <text x="300" y="247" class="t-muted" font-size="8" text-anchor="middle">start or reuse</text>
+        <text x="300" y="265" class="t-cloud" font-size="7" text-anchor="middle">restore caller</text>
 
-        <rect x="470" y="217" width="60" height="52" rx="6" class="c-mask"/>
-        <rect x="470" y="217" width="60" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="500" y="238" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Attach</text>
-        <text x="500" y="255" class="t-muted" font-size="8" text-anchor="middle">binding</text>
+        <rect x="466" y="209" width="68" height="68" rx="6" class="c-mask"/>
+        <rect x="466" y="209" width="68" height="68" rx="6" class="c-backend" stroke-width="1.5"/>
+        <text x="500" y="230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Probe</text>
+        <text x="500" y="247" class="t-muted" font-size="8" text-anchor="middle">physical host</text>
+        <text x="500" y="265" class="t-backend" font-size="7" text-anchor="middle">alive / missing</text>
 
-        <rect x="406" y="341" width="48" height="52" rx="6" class="c-mask"/>
-        <rect x="406" y="341" width="48" height="52" rx="6" class="c-cloud" stroke-width="1.5"/>
-        <text x="430" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Runtime</text>
-        <text x="430" y="379" class="t-muted" font-size="8" text-anchor="middle">host</text>
-
-        <rect x="482" y="341" width="36" height="52" rx="6" class="c-mask"/>
-        <rect x="482" y="341" width="36" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="500" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease</text>
-        <text x="500" y="379" class="t-muted" font-size="8" text-anchor="middle">IDs</text>
-
-        <rect x="579" y="341" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="579" y="341" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
-        <text x="625" y="362" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">PagePort</text>
-        <text x="625" y="379" class="t-muted" font-size="8" text-anchor="middle">callbacks</text>
-
-        <rect x="454" y="465" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="454" y="465" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
-        <text x="500" y="486" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Join Rooms</text>
-        <text x="500" y="503" class="t-muted" font-size="8" text-anchor="middle">10s deadline</text>
+        <rect x="579" y="333" width="92" height="68" rx="6" class="c-mask"/>
+        <rect x="579" y="333" width="92" height="68" rx="6" class="c-messagebus" stroke-width="1.5"/>
+        <text x="625" y="354" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Reuse Runtime</text>
+        <text x="625" y="371" class="t-muted" font-size="8" text-anchor="middle">host + Rooms</text>
+        <text x="625" y="389" class="t-messagebus" font-size="7" text-anchor="middle">keep peers</text>
 
         <rect x="579" y="457" width="92" height="68" rx="6" class="c-mask"/>
-        <rect x="579" y="457" width="92" height="68" rx="6" class="c-database" stroke-width="1.5"/>
-        <text x="625" y="478" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Room State</text>
-        <text x="625" y="495" class="t-muted" font-size="8" text-anchor="middle">Chat / World</text>
-        <text x="625" y="513" class="t-database" font-size="7" text-anchor="middle">Artico owner per room</text>
-
-        <rect x="42" y="589" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="589" width="92" height="52" rx="6" class="c-external" stroke-width="1.5"/>
-        <text x="88" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">System Sleep</text>
-        <text x="88" y="627" class="t-muted" font-size="8" text-anchor="middle">timers pause</text>
-
-        <rect x="174" y="589" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="174" y="589" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="220" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Resume Checks</text>
-        <text x="220" y="627" class="t-muted" font-size="8" text-anchor="middle">same host</text>
-
-        <rect x="384" y="589" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="384" y="589" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="430" y="610" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease Healthy</text>
-        <text x="430" y="627" class="t-muted" font-size="8" text-anchor="middle">no replay</text>
+        <rect x="579" y="457" width="92" height="68" rx="6" class="c-cloud" stroke-width="1.5"/>
+        <text x="625" y="478" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Rebuild</text>
+        <text x="625" y="495" class="t-muted" font-size="8" text-anchor="middle">generation + bind</text>
+        <text x="625" y="513" class="t-cloud" font-size="7" text-anchor="middle">Rooms first</text>
 
         <rect x="579" y="581" width="92" height="68" rx="6" class="c-mask"/>
         <rect x="579" y="581" width="92" height="68" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="625" y="602" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Counts Diverge</text>
-        <text x="625" y="619" class="t-muted" font-size="8" text-anchor="middle">lost callback</text>
-        <text x="625" y="637" class="t-security" font-size="7" text-anchor="middle">confirmed gap</text>
-
-        <rect x="42" y="713" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="713" width="92" height="52" rx="6" class="c-external" stroke-width="1.5"/>
-        <text x="88" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Runtime Lost</text>
-        <text x="88" y="751" class="t-muted" font-size="8" text-anchor="middle">replaced</text>
-
-        <rect x="254" y="713" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="254" y="713" width="92" height="52" rx="6" class="c-cloud" stroke-width="1.5"/>
-        <text x="300" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">New Runtime</text>
-        <text x="300" y="751" class="t-muted" font-size="8" text-anchor="middle">generation +1</text>
-
-        <rect x="409" y="713" width="42" height="52" rx="6" class="c-mask"/>
-        <rect x="409" y="713" width="42" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="430" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Tabs</text>
-        <text x="430" y="751" class="t-muted" font-size="8" text-anchor="middle">pageIds</text>
-
-        <rect x="479" y="713" width="42" height="52" rx="6" class="c-mask"/>
-        <rect x="479" y="713" width="42" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="500" y="734" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Stale</text>
-        <text x="500" y="751" class="t-muted" font-size="8" text-anchor="middle">join</text>
-
-        <rect x="579" y="705" width="92" height="68" rx="6" class="c-mask"/>
-        <rect x="579" y="705" width="92" height="68" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="625" y="726" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No Rooms</text>
-        <text x="625" y="743" class="t-muted" font-size="8" text-anchor="middle">empty host</text>
-        <text x="625" y="761" class="t-security" font-size="7" text-anchor="middle">primary suspect</text>
-
-        <rect x="42" y="837" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="837" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="88" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Refresh Click</text>
-        <text x="88" y="875" class="t-muted" font-size="8" text-anchor="middle">reconnect</text>
-
-        <rect x="195" y="837" width="50" height="52" rx="6" class="c-mask"/>
-        <rect x="195" y="837" width="50" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
-        <text x="220" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">World</text>
-        <text x="220" y="875" class="t-muted" font-size="8" text-anchor="middle">async</text>
-
-        <rect x="275" y="837" width="50" height="52" rx="6" class="c-mask"/>
-        <rect x="275" y="837" width="50" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="300" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Gate</text>
-        <text x="300" y="875" class="t-muted" font-size="8" text-anchor="middle">seed?</text>
-
-        <rect x="409" y="837" width="42" height="52" rx="6" class="c-mask"/>
-        <rect x="409" y="837" width="42" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="430" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Reset</text>
-        <text x="430" y="875" class="t-muted" font-size="8" text-anchor="middle">state</text>
-
-        <rect x="479" y="837" width="42" height="52" rx="6" class="c-mask"/>
-        <rect x="479" y="837" width="42" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
-        <text x="500" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Rejoin</text>
-        <text x="500" y="875" class="t-muted" font-size="8" text-anchor="middle">10s</text>
-
-        <rect x="579" y="837" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="579" y="837" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="625" y="858" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Commit</text>
-        <text x="625" y="875" class="t-muted" font-size="8" text-anchor="middle">settles</text>
-
-        <rect x="402.5" y="961" width="55" height="52" rx="6" class="c-mask"/>
-        <rect x="402.5" y="961" width="55" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="430" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Hold</text>
-        <text x="430" y="999" class="t-muted" font-size="8" text-anchor="middle">cancel</text>
-
-        <rect x="472.5" y="961" width="55" height="52" rx="6" class="c-mask"/>
-        <rect x="472.5" y="961" width="55" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="500" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No-op</text>
-        <text x="500" y="999" class="t-muted" font-size="8" text-anchor="middle">no seed</text>
-
-        <rect x="579" y="961" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="579" y="961" width="92" height="52" rx="6" class="c-security" stroke-width="1.5"/>
-        <text x="625" y="982" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">No Peer</text>
-        <text x="625" y="999" class="t-muted" font-size="8" text-anchor="middle">loading ends</text>
-
-        <rect x="42" y="1085" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="1085" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="88" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">pagehide</text>
-        <text x="88" y="1123" class="t-muted" font-size="8" text-anchor="middle">stop lease</text>
-
-        <rect x="254" y="1085" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="254" y="1085" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="300" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Lease Retained</text>
-        <text x="300" y="1123" class="t-muted" font-size="8" text-anchor="middle">same pageId</text>
-
-        <rect x="454" y="1085" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="454" y="1085" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="500" y="1106" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">pageshow</text>
-        <text x="500" y="1123" class="t-muted" font-size="8" text-anchor="middle">re-register</text>
-
-        <rect x="42" y="1209" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="42" y="1209" width="92" height="52" rx="6" class="c-frontend" stroke-width="1.5"/>
-        <text x="88" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Terminal Exit</text>
-        <text x="88" y="1247" class="t-muted" font-size="8" text-anchor="middle">navigate</text>
-
-        <rect x="254" y="1209" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="254" y="1209" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="300" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">detachPage</text>
-        <text x="300" y="1247" class="t-muted" font-size="8" text-anchor="middle">drop pageId</text>
-
-        <rect x="454" y="1209" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="454" y="1209" width="92" height="52" rx="6" class="c-messagebus" stroke-width="1.5"/>
-        <text x="500" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">5s Grace</text>
-        <text x="500" y="1247" class="t-muted" font-size="8" text-anchor="middle">wait return</text>
-
-        <rect x="579" y="1209" width="92" height="52" rx="6" class="c-mask"/>
-        <rect x="579" y="1209" width="92" height="52" rx="6" class="c-backend" stroke-width="1.5"/>
-        <text x="625" y="1230" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Release Domain</text>
-        <text x="625" y="1247" class="t-muted" font-size="8" text-anchor="middle">leave + clear</text>
+        <text x="625" y="602" class="t-primary" font-size="11" font-weight="600" text-anchor="middle">Rooms Empty</text>
+        <text x="625" y="619" class="t-muted" font-size="8" text-anchor="middle">Refresh no-op</text>
+        <text x="625" y="637" class="t-security" font-size="7" text-anchor="middle">known gap</text>
 
         <!-- Edge labels -->
 
 
-
-
-
-
-
-
-
-
-
-        <rect x="603.2" y="37" width="43.6" height="14" rx="3" class="c-mask"/>
-        <text x="625" y="47" class="t-backend" font-size="8" text-anchor="middle">project</text>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+        <rect x="354.5" y="223" width="82" height="14" rx="3" class="c-mask"/>
+        <text x="395.5" y="233" class="t-backend" font-size="8" text-anchor="middle">restore context</text>
+        <rect x="545.5" y="270" width="34" height="14" rx="3" class="c-mask"/>
+        <text x="562.5" y="280" class="t-backend" font-size="8" text-anchor="middle">alive</text>
+        <rect x="670.2" y="405" width="43.6" height="14" rx="3" class="c-mask"/>
+        <text x="692" y="415" class="t-security" font-size="8" text-anchor="middle">missing</text>
 
 
 
 
         <!-- Legend -->
-        <text x="175" y="1296" class="t-primary" font-size="10" font-weight="600">Legend</text>
-        <rect x="175" y="1308" width="14" height="9" rx="2" class="c-frontend" stroke-width="1"/>
-        <text x="195" y="1316" class="t-muted" font-size="7">User UI</text>
-        <rect x="260" y="1308" width="14" height="9" rx="2" class="c-backend" stroke-width="1"/>
-        <text x="280" y="1316" class="t-muted" font-size="7">Agent logic</text>
-        <rect x="370" y="1308" width="14" height="9" rx="2" class="c-security" stroke-width="1"/>
-        <text x="390" y="1316" class="t-muted" font-size="7">Policy</text>
-        <rect x="455" y="1308" width="14" height="9" rx="2" class="c-messagebus" stroke-width="1"/>
-        <text x="475" y="1316" class="t-muted" font-size="7">Tool action</text>
-        <rect x="565" y="1308" width="14" height="9" rx="2" class="c-database" stroke-width="1"/>
-        <text x="585" y="1316" class="t-muted" font-size="7">Context / trace</text>
+        <text x="175" y="676" class="t-primary" font-size="10" font-weight="600">Legend</text>
+        <rect x="175" y="688" width="14" height="9" rx="2" class="c-frontend" stroke-width="1"/>
+        <text x="195" y="696" class="t-muted" font-size="7">User UI</text>
+        <rect x="260" y="688" width="14" height="9" rx="2" class="c-backend" stroke-width="1"/>
+        <text x="280" y="696" class="t-muted" font-size="7">Agent logic</text>
+        <rect x="370" y="688" width="14" height="9" rx="2" class="c-security" stroke-width="1"/>
+        <text x="390" y="696" class="t-muted" font-size="7">Policy</text>
+        <rect x="455" y="688" width="14" height="9" rx="2" class="c-messagebus" stroke-width="1"/>
+        <text x="475" y="696" class="t-muted" font-size="7">Tool action</text>
+        <rect x="565" y="688" width="14" height="9" rx="2" class="c-database" stroke-width="1"/>
+        <text x="585" y="696" class="t-muted" font-size="7">Context / trace</text>
       </svg>
       </div>
 
@@ -1078,39 +865,39 @@
       <div class="card">
         <div class="card-header">
           <div class="card-dot cyan"></div>
-          <h3>Ownership</h3>
+          <h3>One Gateway</h3>
         </div>
         <ul>
-          <li>&bull; One pageId and UI projection per content document</li>
-          <li>&bull; One Coordinator persists tab-to-page bindings</li>
-          <li>&bull; One shared Runtime owns Chat and World peers</li>
-          <li>&bull; Chat and World counts are projected separately in every tab</li>
-        </ul>
-      </div>
-
-      <div class="card">
-        <div class="card-header">
-          <div class="card-dot rose"></div>
-          <h3>Sleep/Wake Gaps</h3>
-        </div>
-        <ul>
-          <li>&bull; Same host: callback loss has no delivery acknowledgement or replay</li>
-          <li>&bull; New host: rebuildTabs restores page leases, not room aggregates</li>
-          <li>&bull; Content JoinStatus survives while the new Runtime has no rooms</li>
-          <li>&bull; That mismatch explains divergent counts and an empty Runtime</li>
+          <li>&bull; Every backend-bound action enters the same wake gateway</li>
+          <li>&bull; Browser reload and AppButton Refresh are only examples</li>
+          <li>&bull; The original action and caller identity survive recovery</li>
+          <li>&bull; OS sleep, timer pause, BFCache, and page exit are out of scope</li>
         </ul>
       </div>
 
       <div class="card">
         <div class="card-header">
           <div class="card-dot emerald"></div>
-          <h3>Refresh Semantics</h3>
+          <h3>Background + Runtime</h3>
         </div>
         <ul>
-          <li>&bull; The button awaits only the Chat domain operation</li>
-          <li>&bull; World replacement runs independently</li>
-          <li>&bull; A missing Runtime domain and seed produces a successful no-op</li>
-          <li>&bull; A real replacement join has a ten-second outer deadline</li>
+          <li>&bull; Chrome MV3 starts or reuses the Background worker</li>
+          <li>&bull; Firefox persistent Background follows the reuse path</li>
+          <li>&bull; An alive Offscreen host preserves Rooms and runtime data</li>
+          <li>&bull; A missing host rebuilds generation, bindings, and Rooms first</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="card-dot rose"></div>
+          <h3>Known Recovery Gap</h3>
+        </div>
+        <ul>
+          <li>&bull; The current rebuilt-host path restores page leases</li>
+          <li>&bull; It can leave the new Runtime without Chat or World Rooms</li>
+          <li>&bull; AppButton Refresh may then succeed without a domain seed</li>
+          <li>&bull; Room counts can remain inconsistent across content tabs</li>
         </ul>
       </div>
     </div>

--- a/docs/architecture/webchat-runtime-lifecycle.workflow.json
+++ b/docs/architecture/webchat-runtime-lifecycle.workflow.json
@@ -2,463 +2,194 @@
   "schema_version": 1,
   "diagram_type": "workflow",
   "meta": {
-    "title": "WebChat Runtime Lifecycle",
-    "subtitle": "Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect",
+    "title": "WebChat Backend Action Wake Gateway",
+    "subtitle": "Every backend-bound action crosses Background start/reuse and Offscreen probe/rebuild",
     "output": "webchat-runtime-lifecycle.html"
   },
   "lanes": [
-    { "id": "content", "label": "Content Tab" },
-    { "id": "coordinator", "label": "Background Coordinator" },
-    { "id": "runtime", "label": "Shared Runtime Host" },
-    { "id": "rooms", "label": "Rooms + Runtime Data" },
-    { "id": "same_wake", "label": "Wake: Same Host", "variant": "exception" },
-    { "id": "new_wake", "label": "Wake: Rebuilt Host", "variant": "exception" },
-    { "id": "refresh", "label": "AppButton Refresh" },
-    { "id": "refresh_fault", "label": "Refresh No-op / Hold", "variant": "exception" },
-    { "id": "bfcache", "label": "BFCache Suspend / Restore" },
-    { "id": "release", "label": "Terminal Page Release" }
+    { "id": "caller", "label": "Content Caller" },
+    { "id": "background", "label": "Background Gateway" },
+    { "id": "runtime_reuse", "label": "Offscreen Alive" },
+    { "id": "runtime_rebuild", "label": "Offscreen Missing", "variant": "exception" },
+    { "id": "diagnostic", "label": "Current Recovery Gap", "variant": "exception" }
   ],
   "phases": [
-    { "id": "inject", "label": "Inject", "fromCol": 0, "toCol": 0 },
-    { "id": "prepare", "label": "Prepare", "fromCol": 1, "toCol": 1 },
-    { "id": "register", "label": "Register", "fromCol": 2, "toCol": 2 },
-    { "id": "host", "label": "Host", "fromCol": 3, "toCol": 3 },
-    { "id": "attach", "label": "Attach / Join", "fromCol": 4, "toCol": 4 },
-    { "id": "active", "label": "Active / Result", "fromCol": 5, "toCol": 5, "variant": "emphasis" }
+    { "id": "dispatch", "label": "Dispatch", "fromCol": 0, "toCol": 0 },
+    { "id": "background_gate", "label": "Background", "fromCol": 1, "toCol": 2, "variant": "emphasis" },
+    { "id": "runtime_gate", "label": "Offscreen Runtime", "fromCol": 3, "toCol": 5, "variant": "security" }
   ],
   "groups": [],
   "nodes": [
     {
-      "id": "content_injected",
-      "lane": "content",
+      "id": "backend_action",
+      "lane": "caller",
       "col": 0,
       "type": "frontend",
-      "label": "Content Script",
-      "sublabel": "new pageId"
+      "label": "Backend Action",
+      "sublabel": "RPC / operation",
+      "tag": "reload / AppButton"
     },
     {
-      "id": "prepare_local",
-      "lane": "content",
-      "col": 1,
-      "type": "database",
-      "label": "Local",
-      "sublabel": "I/O",
-      "width": 50
-    },
-    {
-      "id": "client_lease",
-      "lane": "content",
-      "col": 2,
-      "type": "frontend",
-      "label": "Lease",
-      "sublabel": "init",
-      "width": 50
-    },
-    {
-      "id": "tab_active",
-      "lane": "content",
+      "id": "resume_action",
+      "lane": "caller",
       "col": 5,
-      "type": "frontend",
-      "label": "Tab Projection",
-      "sublabel": "tab state",
-      "tag": "page-local"
+      "type": "backend",
+      "label": "Resume Action",
+      "sublabel": "original action",
+      "tag": "after recovery"
     },
     {
-      "id": "register_page",
-      "lane": "coordinator",
-      "col": 2,
+      "id": "background_state",
+      "lane": "background",
+      "col": 1,
       "type": "security",
-      "label": "registerPage",
-      "sublabel": "tab + URL"
+      "label": "Active?",
+      "sublabel": "MV3 worker",
+      "width": 50
     },
     {
-      "id": "ensure_host",
-      "lane": "coordinator",
-      "col": 3,
+      "id": "wake_background",
+      "lane": "background",
+      "col": 2,
+      "type": "cloud",
+      "label": "Wake",
+      "sublabel": "start or reuse",
+      "tag": "restore caller",
+      "width": 50
+    },
+    {
+      "id": "probe_offscreen",
+      "lane": "background",
+      "col": 4,
       "type": "backend",
       "label": "Probe",
-      "sublabel": "hostId",
-      "width": 60
+      "sublabel": "physical host",
+      "tag": "alive / missing",
+      "width": 68
     },
     {
-      "id": "attach_page",
-      "lane": "coordinator",
-      "col": 4,
-      "type": "backend",
-      "label": "Attach",
-      "sublabel": "binding",
-      "width": 60
+      "id": "reuse_runtime",
+      "lane": "runtime_reuse",
+      "col": 5,
+      "type": "messagebus",
+      "label": "Reuse Runtime",
+      "sublabel": "host + Rooms",
+      "tag": "keep peers"
     },
     {
-      "id": "runtime_host",
-      "lane": "runtime",
-      "col": 3,
+      "id": "rebuild_runtime",
+      "lane": "runtime_rebuild",
+      "col": 5,
       "type": "cloud",
-      "label": "Runtime",
-      "sublabel": "host",
-      "width": 48
+      "label": "Rebuild",
+      "sublabel": "generation + bind",
+      "tag": "Rooms first"
     },
     {
-      "id": "domain_lease",
-      "lane": "runtime",
-      "col": 4,
-      "type": "backend",
-      "label": "Lease",
-      "sublabel": "IDs",
-      "width": 36
-    },
-    {
-      "id": "page_callbacks",
-      "lane": "runtime",
-      "col": 5,
-      "type": "messagebus",
-      "label": "PagePort",
-      "sublabel": "callbacks"
-    },
-    {
-      "id": "join_rooms",
-      "lane": "rooms",
-      "col": 4,
-      "type": "messagebus",
-      "label": "Join Rooms",
-      "sublabel": "10s deadline"
-    },
-    {
-      "id": "room_state",
-      "lane": "rooms",
-      "col": 5,
-      "type": "database",
-      "label": "Room State",
-      "sublabel": "Chat / World",
-      "tag": "Artico owner per room"
-    },
-    {
-      "id": "sleep_same",
-      "lane": "same_wake",
-      "col": 0,
-      "type": "external",
-      "label": "System Sleep",
-      "sublabel": "timers pause"
-    },
-    {
-      "id": "wake_same",
-      "lane": "same_wake",
-      "col": 1,
-      "type": "backend",
-      "label": "Resume Checks",
-      "sublabel": "same host"
-    },
-    {
-      "id": "passive_check",
-      "lane": "same_wake",
-      "col": 3,
-      "type": "security",
-      "label": "Lease Healthy",
-      "sublabel": "no replay"
-    },
-    {
-      "id": "callback_loss",
-      "lane": "same_wake",
+      "id": "rooms_empty",
+      "lane": "diagnostic",
       "col": 5,
       "type": "security",
-      "label": "Counts Diverge",
-      "sublabel": "lost callback",
-      "tag": "confirmed gap"
-    },
-    {
-      "id": "host_lost",
-      "lane": "new_wake",
-      "col": 0,
-      "type": "external",
-      "label": "Runtime Lost",
-      "sublabel": "replaced"
-    },
-    {
-      "id": "new_generation",
-      "lane": "new_wake",
-      "col": 2,
-      "type": "cloud",
-      "label": "New Runtime",
-      "sublabel": "generation +1"
-    },
-    {
-      "id": "lease_only",
-      "lane": "new_wake",
-      "col": 3,
-      "type": "backend",
-      "label": "Tabs",
-      "sublabel": "pageIds",
-      "width": 42
-    },
-    {
-      "id": "local_join_stale",
-      "lane": "new_wake",
-      "col": 4,
-      "type": "security",
-      "label": "Stale",
-      "sublabel": "join",
-      "width": 42
-    },
-    {
-      "id": "runtime_empty",
-      "lane": "new_wake",
-      "col": 5,
-      "type": "security",
-      "label": "No Rooms",
-      "sublabel": "empty host",
-      "tag": "primary suspect"
-    },
-    {
-      "id": "refresh_click",
-      "lane": "refresh",
-      "col": 0,
-      "type": "frontend",
-      "label": "Refresh Click",
-      "sublabel": "reconnect"
-    },
-    {
-      "id": "world_refresh",
-      "lane": "refresh",
-      "col": 1,
-      "type": "messagebus",
-      "label": "World",
-      "sublabel": "async",
-      "width": 50
-    },
-    {
-      "id": "domain_gate",
-      "lane": "refresh",
-      "col": 2,
-      "type": "security",
-      "label": "Gate",
-      "sublabel": "seed?",
-      "width": 50
-    },
-    {
-      "id": "reset_domain",
-      "lane": "refresh",
-      "col": 3,
-      "type": "backend",
-      "label": "Reset",
-      "sublabel": "state",
-      "width": 42
-    },
-    {
-      "id": "replacement_join",
-      "lane": "refresh",
-      "col": 4,
-      "type": "messagebus",
-      "label": "Rejoin",
-      "sublabel": "10s",
-      "width": 42
-    },
-    { "id": "refresh_done", "lane": "refresh", "col": 5, "type": "backend", "label": "Commit", "sublabel": "settles" },
-    {
-      "id": "history_hold",
-      "lane": "refresh_fault",
-      "col": 3,
-      "type": "security",
-      "label": "Hold",
-      "sublabel": "cancel",
-      "width": 55
-    },
-    {
-      "id": "reconnect_noop",
-      "lane": "refresh_fault",
-      "col": 4,
-      "type": "security",
-      "label": "No-op",
-      "sublabel": "no seed",
-      "width": 55
-    },
-    {
-      "id": "no_peer_result",
-      "lane": "refresh_fault",
-      "col": 5,
-      "type": "security",
-      "label": "No Peer",
-      "sublabel": "loading ends"
-    },
-    {
-      "id": "pagehide_cached",
-      "lane": "bfcache",
-      "col": 0,
-      "type": "frontend",
-      "label": "pagehide",
-      "sublabel": "stop lease"
-    },
-    {
-      "id": "lease_retained",
-      "lane": "bfcache",
-      "col": 2,
-      "type": "backend",
-      "label": "Lease Retained",
-      "sublabel": "same pageId"
-    },
-    {
-      "id": "pageshow_cached",
-      "lane": "bfcache",
-      "col": 4,
-      "type": "frontend",
-      "label": "pageshow",
-      "sublabel": "re-register"
-    },
-    {
-      "id": "terminal_exit",
-      "lane": "release",
-      "col": 0,
-      "type": "frontend",
-      "label": "Terminal Exit",
-      "sublabel": "navigate"
-    },
-    {
-      "id": "detach_runtime",
-      "lane": "release",
-      "col": 2,
-      "type": "backend",
-      "label": "detachPage",
-      "sublabel": "drop pageId"
-    },
-    {
-      "id": "domain_grace",
-      "lane": "release",
-      "col": 4,
-      "type": "messagebus",
-      "label": "5s Grace",
-      "sublabel": "wait return"
-    },
-    {
-      "id": "domain_release",
-      "lane": "release",
-      "col": 5,
-      "type": "backend",
-      "label": "Release Domain",
-      "sublabel": "leave + clear"
+      "label": "Rooms Empty",
+      "sublabel": "Refresh no-op",
+      "tag": "known gap"
     }
   ],
   "edges": [
-    { "from": "content_injected", "to": "prepare_local" },
-    { "from": "prepare_local", "to": "client_lease" },
     {
-      "from": "client_lease",
-      "to": "register_page",
+      "from": "backend_action",
+      "to": "background_state",
       "variant": "emphasis",
       "fromSide": "bottom",
       "toSide": "top",
       "route": "drop"
     },
-    { "from": "register_page", "to": "ensure_host" },
+    { "from": "background_state", "to": "wake_background", "variant": "emphasis" },
     {
-      "from": "ensure_host",
-      "to": "runtime_host",
+      "from": "wake_background",
+      "to": "probe_offscreen",
+      "label": "restore context",
+      "variant": "emphasis"
+    },
+    {
+      "from": "probe_offscreen",
+      "to": "reuse_runtime",
+      "label": "alive",
       "variant": "emphasis",
+      "role": "branch",
       "fromSide": "bottom",
       "toSide": "top",
-      "route": "drop"
+      "route": "drop",
+      "labelSegment": 1
     },
-    { "from": "runtime_host", "to": "domain_lease", "variant": "emphasis" },
     {
-      "from": "attach_page",
-      "to": "domain_lease",
-      "variant": "emphasis",
-      "fromSide": "bottom",
-      "toSide": "top",
-      "route": "drop"
+      "from": "probe_offscreen",
+      "to": "rebuild_runtime",
+      "label": "missing",
+      "variant": "security",
+      "role": "branch",
+      "fromSide": "right",
+      "toSide": "right",
+      "route": "outside-right",
+      "labelDy": 58
     },
-    { "from": "domain_lease", "to": "page_callbacks" },
     {
-      "from": "domain_lease",
-      "to": "join_rooms",
+      "from": "reuse_runtime",
+      "to": "resume_action",
       "variant": "emphasis",
-      "fromSide": "bottom",
-      "toSide": "top",
-      "route": "drop"
-    },
-    { "from": "join_rooms", "to": "room_state", "variant": "emphasis" },
-    {
-      "from": "room_state",
-      "to": "page_callbacks",
-      "variant": "emphasis",
+      "role": "return",
       "fromSide": "top",
       "toSide": "bottom",
       "route": "up-channel"
     },
     {
-      "from": "page_callbacks",
-      "to": "tab_active",
-      "label": "project",
+      "from": "rebuild_runtime",
+      "to": "resume_action",
       "variant": "emphasis",
-      "fromSide": "top",
-      "toSide": "bottom",
-      "route": "up-channel",
-      "labelSegment": 1
+      "role": "return",
+      "fromSide": "right",
+      "toSide": "right",
+      "route": "outside-right"
     },
-    { "from": "sleep_same", "to": "wake_same" },
-    { "from": "wake_same", "to": "passive_check", "variant": "security" },
-    { "from": "passive_check", "to": "callback_loss", "variant": "security", "role": "error" },
-    { "from": "host_lost", "to": "new_generation", "variant": "security" },
-    { "from": "new_generation", "to": "lease_only", "variant": "security" },
-    { "from": "lease_only", "to": "local_join_stale", "variant": "security" },
-    { "from": "local_join_stale", "to": "runtime_empty", "variant": "security", "role": "error" },
-    { "from": "refresh_click", "to": "world_refresh", "variant": "dashed", "role": "async" },
-    { "from": "world_refresh", "to": "domain_gate", "variant": "emphasis" },
-    { "from": "domain_gate", "to": "reset_domain", "variant": "emphasis" },
-    { "from": "reset_domain", "to": "replacement_join", "variant": "emphasis" },
-    { "from": "replacement_join", "to": "refresh_done", "variant": "emphasis" },
     {
-      "from": "reset_domain",
-      "to": "history_hold",
+      "from": "rebuild_runtime",
+      "to": "rooms_empty",
       "variant": "security",
       "role": "error",
       "fromSide": "bottom",
       "toSide": "top",
       "route": "drop"
-    },
-    {
-      "from": "domain_gate",
-      "to": "reconnect_noop",
-      "variant": "security",
-      "role": "error",
-      "fromSide": "bottom",
-      "toSide": "top",
-      "route": "drop"
-    },
-    { "from": "reconnect_noop", "to": "no_peer_result", "variant": "security", "role": "error" },
-    { "from": "pagehide_cached", "to": "lease_retained", "variant": "dashed" },
-    { "from": "lease_retained", "to": "pageshow_cached", "variant": "dashed" },
-    { "from": "terminal_exit", "to": "detach_runtime" },
-    { "from": "detach_runtime", "to": "domain_grace" },
-    { "from": "domain_grace", "to": "domain_release" }
+    }
   ],
   "cards": [
     {
       "dot": "cyan",
-      "title": "Ownership",
+      "title": "One Gateway",
       "items": [
-        "One pageId and UI projection per content document",
-        "One Coordinator persists tab-to-page bindings",
-        "One shared Runtime owns Chat and World peers",
-        "Chat and World counts are projected separately in every tab"
-      ]
-    },
-    {
-      "dot": "rose",
-      "title": "Sleep/Wake Gaps",
-      "items": [
-        "Same host: callback loss has no delivery acknowledgement or replay",
-        "New host: rebuildTabs restores page leases, not room aggregates",
-        "Content JoinStatus survives while the new Runtime has no rooms",
-        "That mismatch explains divergent counts and an empty Runtime"
+        "Every backend-bound action enters the same wake gateway",
+        "Browser reload and AppButton Refresh are only examples",
+        "The original action and caller identity survive recovery",
+        "OS sleep, timer pause, BFCache, and page exit are out of scope"
       ]
     },
     {
       "dot": "emerald",
-      "title": "Refresh Semantics",
+      "title": "Background + Runtime",
       "items": [
-        "The button awaits only the Chat domain operation",
-        "World replacement runs independently",
-        "A missing Runtime domain and seed produces a successful no-op",
-        "A real replacement join has a ten-second outer deadline"
+        "Chrome MV3 starts or reuses the Background worker",
+        "Firefox persistent Background follows the reuse path",
+        "An alive Offscreen host preserves Rooms and runtime data",
+        "A missing host rebuilds generation, bindings, and Rooms first"
+      ]
+    },
+    {
+      "dot": "rose",
+      "title": "Known Recovery Gap",
+      "items": [
+        "The current rebuilt-host path restores page leases",
+        "It can leave the new Runtime without Chat or World Rooms",
+        "AppButton Refresh may then succeed without a domain seed",
+        "Room counts can remain inconsistent across content tabs"
       ]
     }
   ]

--- a/docs/architecture/webchat-runtime-lifecycle.workflow.json
+++ b/docs/architecture/webchat-runtime-lifecycle.workflow.json
@@ -1,0 +1,465 @@
+{
+  "schema_version": 1,
+  "diagram_type": "workflow",
+  "meta": {
+    "title": "WebChat Runtime Lifecycle",
+    "subtitle": "Content tabs, shared host, sleep/wake recovery, page exit, and AppButton reconnect",
+    "output": "webchat-runtime-lifecycle.html"
+  },
+  "lanes": [
+    { "id": "content", "label": "Content Tab" },
+    { "id": "coordinator", "label": "Background Coordinator" },
+    { "id": "runtime", "label": "Shared Runtime Host" },
+    { "id": "rooms", "label": "Rooms + Runtime Data" },
+    { "id": "same_wake", "label": "Wake: Same Host", "variant": "exception" },
+    { "id": "new_wake", "label": "Wake: Rebuilt Host", "variant": "exception" },
+    { "id": "refresh", "label": "AppButton Refresh" },
+    { "id": "refresh_fault", "label": "Refresh No-op / Hold", "variant": "exception" },
+    { "id": "bfcache", "label": "BFCache Suspend / Restore" },
+    { "id": "release", "label": "Terminal Page Release" }
+  ],
+  "phases": [
+    { "id": "inject", "label": "Inject", "fromCol": 0, "toCol": 0 },
+    { "id": "prepare", "label": "Prepare", "fromCol": 1, "toCol": 1 },
+    { "id": "register", "label": "Register", "fromCol": 2, "toCol": 2 },
+    { "id": "host", "label": "Host", "fromCol": 3, "toCol": 3 },
+    { "id": "attach", "label": "Attach / Join", "fromCol": 4, "toCol": 4 },
+    { "id": "active", "label": "Active / Result", "fromCol": 5, "toCol": 5, "variant": "emphasis" }
+  ],
+  "groups": [],
+  "nodes": [
+    {
+      "id": "content_injected",
+      "lane": "content",
+      "col": 0,
+      "type": "frontend",
+      "label": "Content Script",
+      "sublabel": "new pageId"
+    },
+    {
+      "id": "prepare_local",
+      "lane": "content",
+      "col": 1,
+      "type": "database",
+      "label": "Local",
+      "sublabel": "I/O",
+      "width": 50
+    },
+    {
+      "id": "client_lease",
+      "lane": "content",
+      "col": 2,
+      "type": "frontend",
+      "label": "Lease",
+      "sublabel": "init",
+      "width": 50
+    },
+    {
+      "id": "tab_active",
+      "lane": "content",
+      "col": 5,
+      "type": "frontend",
+      "label": "Tab Projection",
+      "sublabel": "tab state",
+      "tag": "page-local"
+    },
+    {
+      "id": "register_page",
+      "lane": "coordinator",
+      "col": 2,
+      "type": "security",
+      "label": "registerPage",
+      "sublabel": "tab + URL"
+    },
+    {
+      "id": "ensure_host",
+      "lane": "coordinator",
+      "col": 3,
+      "type": "backend",
+      "label": "Probe",
+      "sublabel": "hostId",
+      "width": 60
+    },
+    {
+      "id": "attach_page",
+      "lane": "coordinator",
+      "col": 4,
+      "type": "backend",
+      "label": "Attach",
+      "sublabel": "binding",
+      "width": 60
+    },
+    {
+      "id": "runtime_host",
+      "lane": "runtime",
+      "col": 3,
+      "type": "cloud",
+      "label": "Runtime",
+      "sublabel": "host",
+      "width": 48
+    },
+    {
+      "id": "domain_lease",
+      "lane": "runtime",
+      "col": 4,
+      "type": "backend",
+      "label": "Lease",
+      "sublabel": "IDs",
+      "width": 36
+    },
+    {
+      "id": "page_callbacks",
+      "lane": "runtime",
+      "col": 5,
+      "type": "messagebus",
+      "label": "PagePort",
+      "sublabel": "callbacks"
+    },
+    {
+      "id": "join_rooms",
+      "lane": "rooms",
+      "col": 4,
+      "type": "messagebus",
+      "label": "Join Rooms",
+      "sublabel": "10s deadline"
+    },
+    {
+      "id": "room_state",
+      "lane": "rooms",
+      "col": 5,
+      "type": "database",
+      "label": "Room State",
+      "sublabel": "Chat / World",
+      "tag": "Artico owner per room"
+    },
+    {
+      "id": "sleep_same",
+      "lane": "same_wake",
+      "col": 0,
+      "type": "external",
+      "label": "System Sleep",
+      "sublabel": "timers pause"
+    },
+    {
+      "id": "wake_same",
+      "lane": "same_wake",
+      "col": 1,
+      "type": "backend",
+      "label": "Resume Checks",
+      "sublabel": "same host"
+    },
+    {
+      "id": "passive_check",
+      "lane": "same_wake",
+      "col": 3,
+      "type": "security",
+      "label": "Lease Healthy",
+      "sublabel": "no replay"
+    },
+    {
+      "id": "callback_loss",
+      "lane": "same_wake",
+      "col": 5,
+      "type": "security",
+      "label": "Counts Diverge",
+      "sublabel": "lost callback",
+      "tag": "confirmed gap"
+    },
+    {
+      "id": "host_lost",
+      "lane": "new_wake",
+      "col": 0,
+      "type": "external",
+      "label": "Runtime Lost",
+      "sublabel": "replaced"
+    },
+    {
+      "id": "new_generation",
+      "lane": "new_wake",
+      "col": 2,
+      "type": "cloud",
+      "label": "New Runtime",
+      "sublabel": "generation +1"
+    },
+    {
+      "id": "lease_only",
+      "lane": "new_wake",
+      "col": 3,
+      "type": "backend",
+      "label": "Tabs",
+      "sublabel": "pageIds",
+      "width": 42
+    },
+    {
+      "id": "local_join_stale",
+      "lane": "new_wake",
+      "col": 4,
+      "type": "security",
+      "label": "Stale",
+      "sublabel": "join",
+      "width": 42
+    },
+    {
+      "id": "runtime_empty",
+      "lane": "new_wake",
+      "col": 5,
+      "type": "security",
+      "label": "No Rooms",
+      "sublabel": "empty host",
+      "tag": "primary suspect"
+    },
+    {
+      "id": "refresh_click",
+      "lane": "refresh",
+      "col": 0,
+      "type": "frontend",
+      "label": "Refresh Click",
+      "sublabel": "reconnect"
+    },
+    {
+      "id": "world_refresh",
+      "lane": "refresh",
+      "col": 1,
+      "type": "messagebus",
+      "label": "World",
+      "sublabel": "async",
+      "width": 50
+    },
+    {
+      "id": "domain_gate",
+      "lane": "refresh",
+      "col": 2,
+      "type": "security",
+      "label": "Gate",
+      "sublabel": "seed?",
+      "width": 50
+    },
+    {
+      "id": "reset_domain",
+      "lane": "refresh",
+      "col": 3,
+      "type": "backend",
+      "label": "Reset",
+      "sublabel": "state",
+      "width": 42
+    },
+    {
+      "id": "replacement_join",
+      "lane": "refresh",
+      "col": 4,
+      "type": "messagebus",
+      "label": "Rejoin",
+      "sublabel": "10s",
+      "width": 42
+    },
+    { "id": "refresh_done", "lane": "refresh", "col": 5, "type": "backend", "label": "Commit", "sublabel": "settles" },
+    {
+      "id": "history_hold",
+      "lane": "refresh_fault",
+      "col": 3,
+      "type": "security",
+      "label": "Hold",
+      "sublabel": "cancel",
+      "width": 55
+    },
+    {
+      "id": "reconnect_noop",
+      "lane": "refresh_fault",
+      "col": 4,
+      "type": "security",
+      "label": "No-op",
+      "sublabel": "no seed",
+      "width": 55
+    },
+    {
+      "id": "no_peer_result",
+      "lane": "refresh_fault",
+      "col": 5,
+      "type": "security",
+      "label": "No Peer",
+      "sublabel": "loading ends"
+    },
+    {
+      "id": "pagehide_cached",
+      "lane": "bfcache",
+      "col": 0,
+      "type": "frontend",
+      "label": "pagehide",
+      "sublabel": "stop lease"
+    },
+    {
+      "id": "lease_retained",
+      "lane": "bfcache",
+      "col": 2,
+      "type": "backend",
+      "label": "Lease Retained",
+      "sublabel": "same pageId"
+    },
+    {
+      "id": "pageshow_cached",
+      "lane": "bfcache",
+      "col": 4,
+      "type": "frontend",
+      "label": "pageshow",
+      "sublabel": "re-register"
+    },
+    {
+      "id": "terminal_exit",
+      "lane": "release",
+      "col": 0,
+      "type": "frontend",
+      "label": "Terminal Exit",
+      "sublabel": "navigate"
+    },
+    {
+      "id": "detach_runtime",
+      "lane": "release",
+      "col": 2,
+      "type": "backend",
+      "label": "detachPage",
+      "sublabel": "drop pageId"
+    },
+    {
+      "id": "domain_grace",
+      "lane": "release",
+      "col": 4,
+      "type": "messagebus",
+      "label": "5s Grace",
+      "sublabel": "wait return"
+    },
+    {
+      "id": "domain_release",
+      "lane": "release",
+      "col": 5,
+      "type": "backend",
+      "label": "Release Domain",
+      "sublabel": "leave + clear"
+    }
+  ],
+  "edges": [
+    { "from": "content_injected", "to": "prepare_local" },
+    { "from": "prepare_local", "to": "client_lease" },
+    {
+      "from": "client_lease",
+      "to": "register_page",
+      "variant": "emphasis",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    { "from": "register_page", "to": "ensure_host" },
+    {
+      "from": "ensure_host",
+      "to": "runtime_host",
+      "variant": "emphasis",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    { "from": "runtime_host", "to": "domain_lease", "variant": "emphasis" },
+    {
+      "from": "attach_page",
+      "to": "domain_lease",
+      "variant": "emphasis",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    { "from": "domain_lease", "to": "page_callbacks" },
+    {
+      "from": "domain_lease",
+      "to": "join_rooms",
+      "variant": "emphasis",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    { "from": "join_rooms", "to": "room_state", "variant": "emphasis" },
+    {
+      "from": "room_state",
+      "to": "page_callbacks",
+      "variant": "emphasis",
+      "fromSide": "top",
+      "toSide": "bottom",
+      "route": "up-channel"
+    },
+    {
+      "from": "page_callbacks",
+      "to": "tab_active",
+      "label": "project",
+      "variant": "emphasis",
+      "fromSide": "top",
+      "toSide": "bottom",
+      "route": "up-channel",
+      "labelSegment": 1
+    },
+    { "from": "sleep_same", "to": "wake_same" },
+    { "from": "wake_same", "to": "passive_check", "variant": "security" },
+    { "from": "passive_check", "to": "callback_loss", "variant": "security", "role": "error" },
+    { "from": "host_lost", "to": "new_generation", "variant": "security" },
+    { "from": "new_generation", "to": "lease_only", "variant": "security" },
+    { "from": "lease_only", "to": "local_join_stale", "variant": "security" },
+    { "from": "local_join_stale", "to": "runtime_empty", "variant": "security", "role": "error" },
+    { "from": "refresh_click", "to": "world_refresh", "variant": "dashed", "role": "async" },
+    { "from": "world_refresh", "to": "domain_gate", "variant": "emphasis" },
+    { "from": "domain_gate", "to": "reset_domain", "variant": "emphasis" },
+    { "from": "reset_domain", "to": "replacement_join", "variant": "emphasis" },
+    { "from": "replacement_join", "to": "refresh_done", "variant": "emphasis" },
+    {
+      "from": "reset_domain",
+      "to": "history_hold",
+      "variant": "security",
+      "role": "error",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    {
+      "from": "domain_gate",
+      "to": "reconnect_noop",
+      "variant": "security",
+      "role": "error",
+      "fromSide": "bottom",
+      "toSide": "top",
+      "route": "drop"
+    },
+    { "from": "reconnect_noop", "to": "no_peer_result", "variant": "security", "role": "error" },
+    { "from": "pagehide_cached", "to": "lease_retained", "variant": "dashed" },
+    { "from": "lease_retained", "to": "pageshow_cached", "variant": "dashed" },
+    { "from": "terminal_exit", "to": "detach_runtime" },
+    { "from": "detach_runtime", "to": "domain_grace" },
+    { "from": "domain_grace", "to": "domain_release" }
+  ],
+  "cards": [
+    {
+      "dot": "cyan",
+      "title": "Ownership",
+      "items": [
+        "One pageId and UI projection per content document",
+        "One Coordinator persists tab-to-page bindings",
+        "One shared Runtime owns Chat and World peers",
+        "Chat and World counts are projected separately in every tab"
+      ]
+    },
+    {
+      "dot": "rose",
+      "title": "Sleep/Wake Gaps",
+      "items": [
+        "Same host: callback loss has no delivery acknowledgement or replay",
+        "New host: rebuildTabs restores page leases, not room aggregates",
+        "Content JoinStatus survives while the new Runtime has no rooms",
+        "That mismatch explains divergent counts and an empty Runtime"
+      ]
+    },
+    {
+      "dot": "emerald",
+      "title": "Refresh Semantics",
+      "items": [
+        "The button awaits only the Chat domain operation",
+        "World replacement runs independently",
+        "A missing Runtime domain and seed produces a successful no-op",
+        "A real replacement join has a ten-second outer deadline"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add the WebChat Runtime lifecycle workflow to the repository's tracked architecture documentation
- preserve the editable Archify workflow JSON alongside its self-contained generated HTML
- cover startup, room attachment, same-host wake, rebuilt-host wake, AppButton reconnect, BFCache, and terminal page release

## Scope

- `docs/architecture/webchat-runtime-lifecycle.workflow.json`
- `docs/architecture/webchat-runtime-lifecycle.html`
- no source, tests, dependencies, OpenSpec, configuration, or existing architecture files changed

## Validation

- Archify doctor passed
- workflow schema/layout validation passed
- generated HTML artifact check passed
- workflow JSON passes oxfmt check
- generated HTML is byte-identical to the light/dark visually inspected task artifact
- `git diff --check` passed

## Delivery

This PR is documentation-only and remains Draft. No Ready, merge, master promotion, release, or deploy is authorized by this publication.

Head: `dbb1eccc1496b45229ac707d946a8d9285bf6c4f`
Parent: `0b4e77f122b0aaad3c07fe263c83ad1b84df5699`
Tree: `1e1910f6c71df8c033dcf6ec0de60103be14d7f3`
