### PR TITLE
fix(runtime): stabilize final release and concurrent joins

### DIFF
--- a/src/runtime/RemoteRoomTransport.test.ts
+++ b/src/runtime/RemoteRoomTransport.test.ts
@@ -59,6 +59,29 @@ const createService = () => {
 }
 
 describe('RemoteRoomTransport', () => {
+  it('shares one pending physical join for concurrent callers in the same generation and admission', async () => {
+    const fixture = createService()
+    const releaseJoin = deferred<void>()
+    vi.mocked(fixture.service.join).mockImplementation(async (roomId, handle) => {
+      await releaseJoin.promise
+      const room = { roomId, handle, peerId: `peer:${roomId}` }
+      fixture.rooms.set(roomId, room)
+      return room
+    })
+    const transport = new RemoteRoomTransport(fixture.service)
+    await transport.rebind()
+    await transport.activateIngress()
+
+    const first = transport.join('room-a')
+    const second = transport.join('room-a')
+    await Promise.resolve()
+    expect(fixture.join).toHaveBeenCalledOnce()
+
+    releaseJoin.resolve()
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+    expect(transport.peerIdOf('room-a')).toBe('peer:room-a')
+  })
+
   it('waits for every local owner-routing retirement before a successor can join', async () => {
     const fixture = createService()
     fixture.rooms.set('room-a', { roomId: 'room-a', handle: 'handle-a', peerId: 'peer:room-a' })

--- a/src/runtime/RemoteRoomTransport.ts
+++ b/src/runtime/RemoteRoomTransport.ts
@@ -15,6 +15,12 @@ import type {
   TransportService
 } from '@/runtime/TransportHost'
 
+type PendingJoin = {
+  generation: number
+  admission: number
+  task: Promise<void>
+}
+
 /** Background-side facade over Offscreen's physical transport; its rooms are callback-aligned projections. */
 export class RemoteRoomTransport implements RoomTransport {
   private readonly rooms = new Map<string, TransportRoomState>()
@@ -23,6 +29,7 @@ export class RemoteRoomTransport implements RoomTransport {
   private readonly leaves = new Set<(roomId: string, peerId: string) => void>()
   private readonly closes = new Set<(roomId: string) => void>()
   private readonly errors = new Set<(error: Error, roomId: string) => void>()
+  private readonly pendingJoins = new Map<string, PendingJoin>()
   private binding: Promise<void> = Promise.resolve()
   private generation = 0
   private acceptingGeneration = 0
@@ -44,6 +51,7 @@ export class RemoteRoomTransport implements RoomTransport {
   rebind() {
     this.recoveryCapabilityEpoch += 1
     this.invalidateOwner(this.generation)
+    this.pendingJoins.clear()
     const generation = ++this.generation
     this.acceptingGeneration = 0
     const align = (projection: TransportProjection) => {
@@ -280,20 +288,34 @@ export class RemoteRoomTransport implements RoomTransport {
       this.recoveryCapabilityEpoch += 1
     }
   }
-  join = async (roomId: string) => {
+  join = (roomId: string) => {
     const generation = this.generation
+    const existing = this.pendingJoins.get(roomId)
+    if (existing && existing.generation === generation && existing.admission === this.admission) return existing.task
+
     const handle = nanoid()
     const admitted =
       this.acceptingGeneration === generation && !this.rooms.has(roomId)
         ? this.service.join(roomId, handle, this.admission)
         : null
-    await this.binding
-    if (!this.isCurrent(generation)) throw new Error('Room transport generation is no longer current')
-    const existing = this.rooms.get(roomId)
-    if (existing) return
-    const room = await (admitted ?? this.service.join(roomId, handle, this.admission))
-    if (!this.isCurrent(generation)) throw new Error('Room transport generation is no longer current')
-    this.rooms.set(roomId, room)
+    let pending!: PendingJoin
+    const task = (async () => {
+      await this.binding
+      if (!this.isCurrent(generation)) throw new Error('Room transport generation is no longer current')
+      pending.admission = this.admission
+      const current = this.rooms.get(roomId)
+      if (current) return
+      const room = await (admitted ?? this.service.join(roomId, handle, pending.admission))
+      if (!this.isCurrent(generation)) throw new Error('Room transport generation is no longer current')
+      this.rooms.set(roomId, room)
+    })()
+    pending = { generation, admission: this.admission, task }
+    this.pendingJoins.set(roomId, pending)
+    const release = () => {
+      if (this.pendingJoins.get(roomId) === pending) this.pendingJoins.delete(roomId)
+    }
+    void task.then(release, release)
+    return task
   }
   leave = async (roomId: string, options?: { diagnosticOnly?: boolean }) => {
     const generation = this.generation
@@ -371,6 +393,7 @@ export class RemoteRoomTransport implements RoomTransport {
     this.generation += 1
     this.acceptingGeneration = 0
     this.recoveryCapabilityEpoch += 1
+    this.pendingJoins.clear()
     this.pendingIngress = []
     this.rooms.clear()
     this.worldRecoveryState = { members: [], presences: [] }

--- a/src/runtime/Server.test.ts
+++ b/src/runtime/Server.test.ts
@@ -3343,7 +3343,7 @@ describe('RuntimeServer lifecycle', () => {
     disposeServer(server)
   })
 
-  it('refuses a late dual-retire terminal after its caller binding is invalidated', async () => {
+  it('silently cancels a late dual-retire terminal after its caller binding is invalidated', async () => {
     const { fake, server, roomId } = await setup()
     const worldRoomId = getWorldRoomId()
     const releaseRetires = fake.holdRetires()
@@ -3357,11 +3357,51 @@ describe('RuntimeServer lifecycle', () => {
     await removeServerTab(server, 1)
     releaseRetires()
 
-    await expect(reconnect).rejects.toThrow('Runtime presence is completing its final release')
+    await expect(reconnect).resolves.toBeNull()
     await settle()
     expect(fake.joinCalls).toHaveLength(joinsBefore)
     expect(fake.joined).toEqual(new Set())
-    await expect(server.getSnapshot(callerOf(1))).rejects.toThrow('Runtime presence is completing its final release')
+    disposeServer(server)
+  })
+
+  it('keeps a dual replacement live while its exact caller remains current', async () => {
+    const { fake, server, roomId } = await setup()
+    const worldRoomId = getWorldRoomId()
+    const releaseRetires = fake.holdRetires()
+    fake.makeNotReady()
+    const joinsBefore = fake.joinCalls.length
+    const reconnect = server.reconnectDomain({ domain: DOMAIN, ...callerOf(1) })
+
+    await vi.waitFor(() =>
+      expect(fake.operationLog.filter((entry) => entry === `retire:${worldRoomId},${roomId}`)).toHaveLength(1)
+    )
+    releaseRetires()
+    await fake.waitForJoinCalls(joinsBefore + 2)
+    fake.open()
+
+    await expect(reconnect).resolves.toBeUndefined()
+    expect((await readServerSnapshot(server)).domains[0]).toMatchObject({ chatRoomJoined: true })
+    expect((await readServerSnapshot(server)).world.joined).toBe(true)
+    disposeServer(server)
+  })
+
+  it('allows a reattached caller to start a fresh replacement after its old attempt is cancelled', async () => {
+    const { fake, server, roomId } = await setup()
+    const worldRoomId = getWorldRoomId()
+    const releaseRetires = fake.holdRetires()
+    const first = server.reconnectDomain({ domain: DOMAIN, ...callerOf(1) })
+
+    await vi.waitFor(() =>
+      expect(fake.operationLog.filter((entry) => entry === `retire:${worldRoomId},${roomId}`)).toHaveLength(1)
+    )
+    await removeServerTab(server, 1)
+    releaseRetires()
+
+    await expect(first).resolves.toBeNull()
+    await attachTab(server, DOMAIN, 1)
+    await expect(server.reconnectDomain({ domain: DOMAIN, ...callerOf(1) })).resolves.toBeUndefined()
+    expect((await readServerSnapshot(server)).domains[0]).toMatchObject({ chatRoomJoined: true })
+    expect((await readServerSnapshot(server)).world.joined).toBe(true)
     disposeServer(server)
   })
 
@@ -3383,7 +3423,7 @@ describe('RuntimeServer lifecycle', () => {
     releaseIngress()
 
     await expect(leave).resolves.toBeUndefined()
-    await expect(reconnect).rejects.toThrow('Runtime presence is completing its final release')
+    await expect(reconnect).resolves.toBeNull()
     await settle()
     expect(readServerSnapshot(server).domains[0]).toMatchObject({ chatRoomJoined: false, localSession: undefined })
     expect(readServerSnapshot(server).world).toMatchObject({ joined: false, localPresence: undefined, presences: [] })
@@ -3408,7 +3448,7 @@ describe('RuntimeServer lifecycle', () => {
     disposeServer(server)
     releaseIngress()
 
-    await expect(reconnect).rejects.toThrow('Runtime presence is completing its final release')
+    await expect(reconnect).resolves.toBeNull()
     expect(fake.joined).toEqual(new Set())
   })
 

--- a/src/runtime/Server.ts
+++ b/src/runtime/Server.ts
@@ -553,6 +553,8 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
   // A reservation covers the pre-cut release barrier. It owns no recovered facts and exists
   // solely so detach/rebind can cancel the same explicit click before an attempt is captured.
   const replacementReservations = new Map<string, ReplacementReservation>()
+  const cancelledReplacementReservations = new WeakSet<ReplacementReservation>()
+  const cancelledReplacementAttempts = new WeakSet<DualReplacementAttempt>()
   const replacementSeeds = new Map<string, DualReplacementSeed>()
   let sharedWorldRecovery: SharedWorldRecoveryEpoch | undefined
   let currentWorldReplacement: DualReplacementAttempt | undefined
@@ -668,11 +670,13 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
     for (const [domain, attempt] of replacementAttempts) {
       if (attempt.tabId !== tabId) continue
       attempt.invalidated = true
+      cancelledReplacementAttempts.add(attempt)
       replacementSeeds.delete(domain)
     }
     for (const [domain, reservation] of replacementReservations) {
       if (reservation.tabId !== tabId) continue
       reservation.invalidated = true
+      cancelledReplacementReservations.add(reservation)
       replacementSeeds.delete(domain)
     }
     for (const [domain, seed] of replacementSeeds) {
@@ -684,9 +688,15 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
   }
   const invalidateReplacementForDomain = (domain: string) => {
     const attempt = replacementAttempts.get(domain)
-    if (attempt) attempt.invalidated = true
+    if (attempt) {
+      attempt.invalidated = true
+      cancelledReplacementAttempts.add(attempt)
+    }
     const reservation = replacementReservations.get(domain)
-    if (reservation) reservation.invalidated = true
+    if (reservation) {
+      reservation.invalidated = true
+      cancelledReplacementReservations.add(reservation)
+    }
     replacementSeeds.delete(domain)
     if (sharedWorldRecovery?.world.some((registration) => registration.domain === domain)) {
       sharedWorldRecovery = undefined
@@ -701,6 +711,7 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
       currentWorldReplacement !== attempt ||
       attempt.hostId !== connectionOptions.hostId
     ) {
+      if (disposed) cancelledReplacementAttempts.add(attempt)
       throw operationCancelled()
     }
     const tabId = await requireCallerTab(payload, attempt.domain, { allowRecoveryFailure: true })
@@ -721,6 +732,7 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
       replacementReservations.get(reservation.domain) !== reservation ||
       reservation.hostId !== connectionOptions.hostId
     ) {
+      if (disposed) cancelledReplacementReservations.add(reservation)
       throw operationCancelled()
     }
     const tabId = await requireCallerTab(payload, reservation.domain, { allowRecoveryFailure: true })
@@ -1231,7 +1243,8 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
   const runReservedDualReplacement = async (
     reservation: ReplacementReservation,
     payload: RuntimePageCall
-  ): Promise<undefined> => {
+  ): Promise<undefined | null> => {
+    let attempt: DualReplacementAttempt | undefined
     try {
       const releaseBarrier = captureActiveReleaseBarrier()
       if (releaseBarrier.releases.length > 0) {
@@ -1277,7 +1290,7 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
       }
       const sequence = replacementSequence + 1
       replacementSequence = sequence
-      const attempt: DualReplacementAttempt = {
+      attempt = {
         ...cloneSeed(captured),
         epoch: `manual:${reservation.domain}:${sequence}`,
         invalidated: false
@@ -1289,6 +1302,15 @@ export const createServer = (config: ServerConfig): RuntimeServer => {
       replacementReservations.delete(reservation.domain)
       replacementAttempts.set(reservation.domain, attempt)
       return await runDualReplacement(attempt, payload, releaseBarrier)
+    } catch (error) {
+      // Cancellation is owned by this exact reservation/attempt, never inferred from an error message.
+      if (
+        cancelledReplacementReservations.has(reservation) ||
+        (attempt !== undefined && cancelledReplacementAttempts.has(attempt))
+      ) {
+        return null
+      }
+      throw error
     } finally {
       if (replacementReservations.get(reservation.domain) === reservation) {
         replacementReservations.delete(reservation.domain)

--- a/src/runtime/TransportHost.test.ts
+++ b/src/runtime/TransportHost.test.ts
@@ -148,8 +148,9 @@ describe('Offscreen TransportService', () => {
 
     releaseJoin()
     await expect(first).resolves.toMatchObject({ roomId: 'room-a', handle: 'handle-a' })
-    await expect(second).rejects.toThrow('owned by a newer handle')
+    await expect(second).rejects.toThrow('conflicting current owner')
     await expect(service.join('room-a', 'handle-a', binding.admission)).resolves.toMatchObject({ handle: 'handle-a' })
+    await expect(service.join('room-a', 'handle-b', binding.admission)).rejects.toThrow('conflicting current owner')
     expect(fixture.join).toHaveBeenCalledOnce()
   })
 

--- a/src/runtime/TransportHost.ts
+++ b/src/runtime/TransportHost.ts
@@ -267,13 +267,13 @@ export const createTransportService = (transport: RoomTransport = createRoomTran
       if (joinAdmission !== admission) throw new Error('Transport room admission is no longer current')
       const existing = rooms.get(roomId)
       if (existing) {
-        if (existing.handle !== handle) throw new Error('Transport room is owned by a newer handle')
+        if (existing.handle !== handle) throw new Error('Transport room has a conflicting current owner')
         return existing
       }
       const pending = joining.get(roomId)
       if (pending) {
         const room = await pending
-        if (room.handle !== handle) throw new Error('Transport room is owned by a newer handle')
+        if (room.handle !== handle) throw new Error('Transport room has a conflicting current owner')
         return room
       }
       const task = (async () => {


### PR DESCRIPTION
## Summary

- Classifies only exact tab/domain invalidation and disposed-host cancellations
  as normal completion; genuine stale-owner failure remains fail-closed.
- Shares a pending physical join and handle for concurrent matching
  `RemoteRoomTransport` room/generation/admission requests while retaining
  stale-handle fencing.
- Rewords the current-owner conflict without asserting temporal ordering or
  exposing a handle.

## Validation

- Candidate: `b17f3dedded1b3c0152a26018d619342e089db22`
- Independent review: task #1640 `CODE FINAL PASS 0/0/0`
- Local controls: focused runtime `246/246`, runtime `395/395`, serial full
  suite `1061/1061`, TypeScript check, format check, lint check (existing
  warnings only), and Chrome/Firefox production builds passed.

The default parallel test command retains four markdown-preview
`ResizeObserver` console-error failures that reproduce on the clean parent;
the individual targets and serial suite are green.
