### PR TITLE
feat(message-list): follow latest without interrupting browsing

### DIFF
--- a/src/app/content/App.render.test.tsx
+++ b/src/app/content/App.render.test.tsx
@@ -1,10 +1,11 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const fixture = vi.hoisted(() => ({
   ready: false,
   danmakuEnabled: false,
   danmakuMountKeys: [] as string[],
+  localSendTokens: [] as number[],
   onDanmakuClick: null as null | (() => void),
   send: vi.fn()
 }))
@@ -73,8 +74,19 @@ vi.mock('@/domain/Danmaku', () => ({
   })
 }))
 vi.mock('@/app/content/views/header', () => ({ default: () => <header data-testid="header" /> }))
-vi.mock('@/app/content/views/main', () => ({ default: () => <main data-testid="main" /> }))
-vi.mock('@/app/content/views/footer', () => ({ default: () => <footer data-testid="footer" /> }))
+vi.mock('@/app/content/views/main', () => ({
+  default: ({ localSendToken }: { localSendToken: number }) => {
+    fixture.localSendTokens.push(localSendToken)
+    return <main data-testid="main" data-local-send-token={localSendToken} />
+  }
+}))
+vi.mock('@/app/content/views/footer', () => ({
+  default: ({ onLocalTextSent }: { onLocalTextSent: () => void }) => (
+    <footer data-testid="footer">
+      <button type="button" data-testid="local-text-send" onClick={onLocalTextSent} />
+    </footer>
+  )
+}))
 vi.mock('@/app/content/views/setup', () => ({ default: () => <aside data-testid="setup" /> }))
 vi.mock('@/app/content/views/app-layout', () => ({
   default: ({ children }: { children?: React.ReactNode }) => (
@@ -103,6 +115,7 @@ afterEach(() => {
   fixture.ready = false
   fixture.danmakuEnabled = false
   fixture.danmakuMountKeys = []
+  fixture.localSendTokens = []
   fixture.onDanmakuClick = null
   fixture.send.mockClear()
   vi.restoreAllMocks()
@@ -144,6 +157,17 @@ describe('normal App composition', () => {
     fixture.onDanmakuClick!()
 
     expect(fixture.send).toHaveBeenCalledExactlyOnceWith('update-open-true')
+  })
+
+  it('forwards each Footer local-text dispatch through one Document-local token to Main', () => {
+    render(<App />)
+
+    expect(screen.getByTestId('main').dataset.localSendToken).toBe('0')
+    fireEvent.click(screen.getByTestId('local-text-send'))
+    expect(screen.getByTestId('main').dataset.localSendToken).toBe('1')
+    fireEvent.click(screen.getByTestId('local-text-send'))
+    expect(screen.getByTestId('main').dataset.localSendToken).toBe('2')
+    expect(fixture.localSendTokens).toEqual([0, 1, 2])
   })
 
   it('keeps the Danmaku mount interface visibility-free', () => {

--- a/src/app/content/App.tsx
+++ b/src/app/content/App.tsx
@@ -1,5 +1,5 @@
 import '@webcomponents/custom-elements'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRemeshDomain, useRemeshQuery, useRemeshSend } from 'remesh-react'
 import { Toaster } from 'sonner'
 import Header from '@/app/content/views/header'
@@ -44,7 +44,9 @@ const App = () => {
   const danmakuIsEnabled = userInfo?.danmakuEnabled ?? false
   const danmakuContainerRef = useRef<HTMLDivElement>(null)
   const mediaPreviewRef = useRef<MediaPreviewHandle>(null)
+  const [localSendToken, setLocalSendToken] = useState(0)
   const openMediaPreview = useCallback((request: MediaPreviewRequest) => mediaPreviewRef.current?.open(request), [])
+  const handleLocalTextSent = useCallback(() => setLocalSendToken((token) => token + 1), [])
 
   useEffect(() => {
     if (initializationReady && messageListLoadFinished && userInfoSetFinished) {
@@ -85,8 +87,8 @@ const App = () => {
       <MediaPreviewContext.Provider value={openMediaPreview}>
         <AppLayout>
           <Header />
-          <Main />
-          <Footer />
+          <Main localSendToken={localSendToken} />
+          <Footer onLocalTextSent={handleLocalTextSent} />
           {notUserInfo && <Setup />}
           <Toaster
             richColors

--- a/src/app/content/components/message-list.browser.test.tsx
+++ b/src/app/content/components/message-list.browser.test.tsx
@@ -31,15 +31,17 @@ const groupedRow = (
     last
   />
 )
-const harness = (historyReady: boolean, children: ReactElement[]) => (
-  <div style={{ display: 'grid', gridTemplateRows: '1fr', height: '240px', width: '360px' }}>
-    <MessageList>{historyReady ? children : null}</MessageList>
+const harness = (historyReady: boolean, children: ReactElement[], width = 360, height = 240, localSendToken = 0) => (
+  <div style={{ display: 'grid', gridTemplateRows: '1fr', height: `${height}px`, width: `${width}px` }}>
+    <MessageList localSendToken={localSendToken}>{historyReady ? children : null}</MessageList>
   </div>
 )
 const viewport = () => document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
 const list = () => document.querySelector<HTMLElement>('[data-testid="virtuoso-item-list"]')
 const atBottom = (element: HTMLElement) => element.scrollTop + element.clientHeight >= element.scrollHeight - 1
-const followAction = (label: string) => document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+const followAction = (label: string) =>
+  document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"][data-state="open"]`)
+const followActionElement = () => document.querySelector<HTMLButtonElement>('[data-testid="follow-latest-action"]')
 type ScrollCall = ScrollToOptions | readonly [number, number | undefined]
 const isScrollOptions = (call: ScrollCall): call is ScrollToOptions => !Array.isArray(call)
 const suppressResizeObserverLoop = (event: ErrorEvent) => {
@@ -155,13 +157,89 @@ describe('MessageList initial settlement', () => {
     await frame()
 
     expect(scrollParent.scrollTop).toBe(0)
-    const action = followAction('1 条新消息')
+    const action = followAction('1 new message')
     expect(action).not.toBeNull()
 
     action!.click()
     await vi.waitFor(() => {
       expect(atBottom(scrollParent)).toBe(true)
-      expect(followAction('回到底部')).toBeNull()
+      expect(followAction('Scroll to latest messages')).toBeNull()
+    })
+  })
+
+  it('centers the ArrowDown action across desktop and narrow list widths and retains its fade exit node', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows, 360))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+
+    const assertCentered = () => {
+      const action = followAction('Scroll to latest messages')
+      expect(action).not.toBeNull()
+      expect(action!.textContent).toBe('')
+      const viewportBounds = scrollParent.getBoundingClientRect()
+      const actionBounds = action!.getBoundingClientRect()
+      expect(
+        Math.abs(actionBounds.left + actionBounds.width / 2 - (viewportBounds.left + viewportBounds.width / 2))
+      ).toBeLessThan(1)
+    }
+
+    await vi.waitFor(assertCentered)
+    await view.rerender(harness(true, initialRows, 220))
+    await vi.waitFor(assertCentered)
+
+    const action = followActionElement()
+    expect(action).not.toBeNull()
+    expect(action!.className).toContain('transition-[opacity,grid-template-columns,gap,padding]')
+
+    scrollParent.scrollTo({ top: scrollParent.scrollHeight - scrollParent.clientHeight, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).toBeNull())
+    expect(followActionElement()).toBe(action)
+    expect(action!.dataset.state).toBe('closed')
+  })
+
+  it('shows only beyond a half-screen of remaining distance and hides at or below it', async () => {
+    const initialRows = history(32)
+    await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+
+    const maxScrollTop = scrollParent.scrollHeight - scrollParent.clientHeight
+    const beyondHalfDistance = Math.ceil(scrollParent.clientHeight * 0.51)
+    scrollParent.scrollTo({ top: maxScrollTop - beyondHalfDistance, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
+
+    const withinHalfDistance = Math.floor(scrollParent.clientHeight * 0.49)
+    scrollParent.scrollTo({ top: maxScrollTop - withinHalfDistance, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).toBeNull())
+    expect(followActionElement()?.dataset.state).toBe('closed')
+  })
+
+  it('forces the latest local projection to the bottom after a successful local send token', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows, 360, 240, 0))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
+
+    await view.rerender(harness(true, [...initialRows, row('local-send', 88)], 360, 240, 1))
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-local-send"]')).not.toBeNull()
+      expect(atBottom(scrollParent)).toBe(true)
+      expect(followAction('Scroll to latest messages')).toBeNull()
     })
   })
 
@@ -184,21 +262,21 @@ describe('MessageList initial settlement', () => {
       expect(document.querySelector('[data-testid="message-0"]')).not.toBeNull()
     })
     scrollParent.dispatchEvent(new Event('scroll'))
-    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
 
     const rowsWithN1 = [...initialRows, row('n1', 72)]
     await view.rerender(harness(true, rowsWithN1))
-    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
+    await vi.waitFor(() => expect(followAction('1 new message')).not.toBeNull())
 
-    followAction('1 条新消息')!.click()
+    followAction('1 new message')!.click()
     await view.rerender(harness(true, [...rowsWithN1, row('n2', 104)]))
 
     await vi.waitFor(
       () => {
         expect(document.querySelector('[data-testid="message-n2"]')).not.toBeNull()
         expect(atBottom(scrollParent)).toBe(true)
-        expect(followAction('回到底部')).toBeNull()
-        expect(followAction('1 条新消息')).toBeNull()
+        expect(followAction('Scroll to latest messages')).toBeNull()
+        expect(followAction('1 new message')).toBeNull()
       },
       { timeout: 5_000 }
     )
@@ -223,13 +301,13 @@ describe('MessageList initial settlement', () => {
       expect(document.querySelector('[data-testid="message-0"]')).not.toBeNull()
     })
     scrollParent.dispatchEvent(new Event('scroll'))
-    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
 
     const rowsWithN1 = [...initialRows, row('n1', 72)]
     await view.rerender(harness(true, rowsWithN1))
-    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
+    await vi.waitFor(() => expect(followAction('1 new message')).not.toBeNull())
 
-    followAction('1 条新消息')!.click()
+    followAction('1 new message')!.click()
     scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
     scrollParent.scrollTo({ top: 0, behavior: 'auto' })
     scrollParent.dispatchEvent(new Event('scroll'))
@@ -237,7 +315,7 @@ describe('MessageList initial settlement', () => {
 
     await vi.waitFor(() => {
       expect(scrollParent.scrollTop).toBe(0)
-      expect(followAction('1 条新消息')).not.toBeNull()
+      expect(followAction('1 new message')).not.toBeNull()
     })
   })
 
@@ -251,12 +329,12 @@ describe('MessageList initial settlement', () => {
     scrollParent.scrollTo({ top: 0, behavior: 'auto' })
     scrollParent.dispatchEvent(new Event('scroll'))
 
-    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
-    followAction('回到底部')!.click()
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
+    followAction('Scroll to latest messages')!.click()
 
     await vi.waitFor(() => {
       expect(atBottom(scrollParent)).toBe(true)
-      expect(followAction('回到底部')).toBeNull()
+      expect(followAction('Scroll to latest messages')).toBeNull()
     })
   })
 
@@ -304,8 +382,8 @@ describe('MessageList initial settlement', () => {
       expect(Math.abs(position.offset - anchorOffset)).toBeLessThan(2)
     })
 
-    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
-    expect(followAction('1 条新消息')).toBeNull()
+    await vi.waitFor(() => expect(followAction('Scroll to latest messages')).not.toBeNull())
+    expect(followAction('1 new message')).toBeNull()
   })
 
   it('rebases the reading anchor and counts the tail in one canonical head-plus-tail snapshot', async () => {
@@ -346,8 +424,8 @@ describe('MessageList initial settlement', () => {
         Math.abs(currentAnchor!.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top - anchorOffset)
       ).toBeLessThan(2)
     })
-    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
-    expect(followAction('回到底部')).toBeNull()
+    await vi.waitFor(() => expect(followAction('1 new message')).not.toBeNull())
+    expect(followAction('Scroll to latest messages')).toBeNull()
   })
 
   it('first presents a non-empty short history at its natural position without a settlement scroll', async () => {

--- a/src/app/content/components/message-list.browser.test.tsx
+++ b/src/app/content/components/message-list.browser.test.tsx
@@ -165,6 +165,82 @@ describe('MessageList initial settlement', () => {
     })
   })
 
+  it('keeps click recovery current when N2 arrives before the first smooth travel reaches the bottom', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-23"]')).not.toBeNull()
+      expect(atBottom(scrollParent)).toBe(true)
+    })
+    await frame()
+    await frame()
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => {
+      expect(scrollParent.scrollTop).toBe(0)
+      expect(document.querySelector('[data-testid="message-0"]')).not.toBeNull()
+    })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+
+    const rowsWithN1 = [...initialRows, row('n1', 72)]
+    await view.rerender(harness(true, rowsWithN1))
+    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
+
+    followAction('1 条新消息')!.click()
+    await view.rerender(harness(true, [...rowsWithN1, row('n2', 104)]))
+
+    await vi.waitFor(
+      () => {
+        expect(document.querySelector('[data-testid="message-n2"]')).not.toBeNull()
+        expect(atBottom(scrollParent)).toBe(true)
+        expect(followAction('回到底部')).toBeNull()
+        expect(followAction('1 条新消息')).toBeNull()
+      },
+      { timeout: 5_000 }
+    )
+  })
+
+  it('cancels click recovery when a manual departure occurs before N2', async () => {
+    const initialRows = history(24)
+    const view = await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-23"]')).not.toBeNull()
+      expect(atBottom(scrollParent)).toBe(true)
+    })
+    await frame()
+    await frame()
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => {
+      expect(scrollParent.scrollTop).toBe(0)
+      expect(document.querySelector('[data-testid="message-0"]')).not.toBeNull()
+    })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+
+    const rowsWithN1 = [...initialRows, row('n1', 72)]
+    await view.rerender(harness(true, rowsWithN1))
+    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
+
+    followAction('1 条新消息')!.click()
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+    await view.rerender(harness(true, [...rowsWithN1, row('n2', 104)]))
+
+    await vi.waitFor(() => {
+      expect(scrollParent.scrollTop).toBe(0)
+      expect(followAction('1 条新消息')).not.toBeNull()
+    })
+  })
+
   it('shows the zero-count return action while browsing older messages', async () => {
     const initialRows = history(24)
     await render(harness(true, initialRows))
@@ -230,6 +306,48 @@ describe('MessageList initial settlement', () => {
 
     await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
     expect(followAction('1 条新消息')).toBeNull()
+  })
+
+  it('rebases the reading anchor and counts the tail in one canonical head-plus-tail snapshot', async () => {
+    const currentRows = history(36)
+    const view = await render(harness(true, currentRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    await vi.waitFor(() => expect(scrollParent.scrollHeight).toBeGreaterThan(scrollParent.clientHeight))
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-35"]')).not.toBeNull()
+      expect(getComputedStyle(list()!).visibility).not.toBe('hidden')
+    })
+    const manualScrollTop = scrollParent.scrollHeight - scrollParent.clientHeight - 160
+    expect(manualScrollTop).toBeGreaterThan(0)
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: manualScrollTop, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+
+    const viewportBounds = scrollParent.getBoundingClientRect()
+    const anchor = Array.from(document.querySelectorAll<HTMLElement>('[data-testid^="message-"]')).find((row) => {
+      const bounds = row.getBoundingClientRect()
+      return bounds.top >= viewportBounds.top && bounds.bottom <= viewportBounds.bottom
+    })
+    expect(scrollParent.scrollTop).toBe(manualScrollTop)
+    expect(anchor).toBeDefined()
+    const anchorTestId = anchor!.dataset.testid!
+    const anchorOffset = anchor!.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top
+
+    await view.rerender(
+      harness(true, [row('history-head-1', 88), row('history-head-2', 120), ...currentRows, row('new-tail', 104)])
+    )
+
+    await vi.waitFor(() => {
+      const currentAnchor = document.querySelector<HTMLElement>(`[data-testid="${anchorTestId}"]`)
+      expect(currentAnchor).not.toBeNull()
+      expect(
+        Math.abs(currentAnchor!.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top - anchorOffset)
+      ).toBeLessThan(2)
+    })
+    await vi.waitFor(() => expect(followAction('1 条新消息')).not.toBeNull())
+    expect(followAction('回到底部')).toBeNull()
   })
 
   it('first presents a non-empty short history at its natural position without a settlement scroll', async () => {

--- a/src/app/content/components/message-list.browser.test.tsx
+++ b/src/app/content/components/message-list.browser.test.tsx
@@ -39,6 +39,7 @@ const harness = (historyReady: boolean, children: ReactElement[]) => (
 const viewport = () => document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
 const list = () => document.querySelector<HTMLElement>('[data-testid="virtuoso-item-list"]')
 const atBottom = (element: HTMLElement) => element.scrollTop + element.clientHeight >= element.scrollHeight - 1
+const followAction = (label: string) => document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
 type ScrollCall = ScrollToOptions | readonly [number, number | undefined]
 const isScrollOptions = (call: ScrollCall): call is ScrollToOptions => !Array.isArray(call)
 const suppressResizeObserverLoop = (event: ErrorEvent) => {
@@ -137,6 +138,7 @@ describe('MessageList initial settlement', () => {
     await frame()
     await frame()
 
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
     scrollParent.scrollTo({ top: 0, behavior: 'auto' })
     scrollParent.dispatchEvent(new Event('scroll'))
     await vi.waitFor(() => {
@@ -153,6 +155,81 @@ describe('MessageList initial settlement', () => {
     await frame()
 
     expect(scrollParent.scrollTop).toBe(0)
+    const action = followAction('1 条新消息')
+    expect(action).not.toBeNull()
+
+    action!.click()
+    await vi.waitFor(() => {
+      expect(atBottom(scrollParent)).toBe(true)
+      expect(followAction('回到底部')).toBeNull()
+    })
+  })
+
+  it('shows the zero-count return action while browsing older messages', async () => {
+    const initialRows = history(24)
+    await render(harness(true, initialRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: 0, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+
+    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+    followAction('回到底部')!.click()
+
+    await vi.waitFor(() => {
+      expect(atBottom(scrollParent)).toBe(true)
+      expect(followAction('回到底部')).toBeNull()
+    })
+  })
+
+  it('preserves the reading anchor and never counts a stable-key history prepend as a new tail message', async () => {
+    const currentRows = history(36)
+    const view = await render(harness(true, currentRows))
+    const scrollParent = viewport()
+
+    await vi.waitFor(() => expect(atBottom(scrollParent)).toBe(true))
+    await vi.waitFor(() => expect(scrollParent.scrollHeight).toBeGreaterThan(scrollParent.clientHeight))
+    await vi.waitFor(() => {
+      expect(document.querySelector('[data-testid="message-35"]')).not.toBeNull()
+      expect(getComputedStyle(list()!).visibility).not.toBe('hidden')
+    })
+    const manualScrollTop = scrollParent.scrollHeight - scrollParent.clientHeight - 160
+    expect(manualScrollTop).toBeGreaterThan(0)
+    scrollParent.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: -120 }))
+    scrollParent.scrollTo({ top: manualScrollTop, behavior: 'auto' })
+    scrollParent.dispatchEvent(new Event('scroll'))
+
+    const viewportBounds = scrollParent.getBoundingClientRect()
+    const anchor = Array.from(document.querySelectorAll<HTMLElement>('[data-testid^="message-"]')).find((row) => {
+      const bounds = row.getBoundingClientRect()
+      return bounds.top >= viewportBounds.top && bounds.bottom <= viewportBounds.bottom
+    })
+    expect(scrollParent.scrollTop).toBe(manualScrollTop)
+    expect(anchor).toBeDefined()
+    const anchorTestId = anchor!.dataset.testid!
+    const anchorOffset = anchor!.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top
+    const scrollHeightBeforePrepend = scrollParent.scrollHeight
+    await view.rerender(harness(true, [row('history-head-1', 88), row('history-head-2', 120), ...currentRows]))
+    const readAnchorPosition = () => {
+      const currentAnchor = document.querySelector<HTMLElement>(`[data-testid="${anchorTestId}"]`)
+      expect(currentAnchor).not.toBeNull()
+      return {
+        offset: currentAnchor!.getBoundingClientRect().top - scrollParent.getBoundingClientRect().top,
+        scrollHeight: scrollParent.scrollHeight,
+        scrollTop: scrollParent.scrollTop
+      }
+    }
+    await vi.waitFor(() => {
+      const position = readAnchorPosition()
+
+      expect(position.scrollHeight).toBeGreaterThan(scrollHeightBeforePrepend)
+      expect(Math.abs(position.offset - anchorOffset)).toBeLessThan(2)
+    })
+
+    await vi.waitFor(() => expect(followAction('回到底部')).not.toBeNull())
+    expect(followAction('1 条新消息')).toBeNull()
   })
 
   it('first presents a non-empty short history at its natural position without a settlement scroll', async () => {

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -1,7 +1,7 @@
 import { createElement, useEffect, type ReactElement, type Ref } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { act, cleanup, render } from '@testing-library/react'
-import type { VirtuosoProps } from 'react-virtuoso'
+import type { VirtuosoHandle, VirtuosoProps } from 'react-virtuoso'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MESSAGE_RECORD_TYPE, NOTICE_TYPE, type DisplayMessage, type SystemNoticeMessage } from '@/domain/Message'
 import MessageList from './message-list'
@@ -11,15 +11,25 @@ import NoticeItem from './notice-item'
 
 interface VirtuosoCall {
   alignToBottom?: boolean
+  atBottomStateChange?: VirtuosoProps<ReactElement, unknown>['atBottomStateChange']
   customScrollParent?: HTMLElement
   data: readonly ReactElement[]
   followOutput?: VirtuosoProps<ReactElement, unknown>['followOutput']
   initialTopMostItemIndex?: VirtuosoProps<ReactElement, unknown>['initialTopMostItemIndex']
+  isScrolling?: VirtuosoProps<ReactElement, unknown>['isScrolling']
   keys: (string | number | bigint)[]
 }
 
 const virtuosoCalls = vi.hoisted(() => [] as VirtuosoCall[])
 const virtuosoLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }))
+const virtuosoHandle = vi.hoisted(() => ({
+  autoscrollToBottom: vi.fn(),
+  getState: vi.fn(),
+  scrollBy: vi.fn(),
+  scrollIntoView: vi.fn(),
+  scrollTo: vi.fn(),
+  scrollToIndex: vi.fn()
+}))
 const scrollAreaRefControl = vi.hoisted(() => ({ manual: false, ref: null as Ref<HTMLDivElement> | null }))
 
 vi.mock('@/components/ui/scroll-area', async () => {
@@ -29,8 +39,13 @@ vi.mock('@/components/ui/scroll-area', async () => {
       scrollAreaRefControl.ref = ref ?? null
       return React.createElement(
         'div',
-        { 'data-testid': 'scroll-area' },
-        React.createElement('div', { ref: scrollAreaRefControl.manual ? undefined : ref }, children)
+        { 'data-slot': 'scroll-area', 'data-testid': 'scroll-area' },
+        React.createElement(
+          'div',
+          { 'data-slot': 'scroll-area-viewport', ref: scrollAreaRefControl.manual ? undefined : ref },
+          children
+        ),
+        React.createElement('div', { 'data-slot': 'scroll-area-scrollbar', 'data-testid': 'scrollbar' })
       )
     }
   }
@@ -39,19 +54,31 @@ vi.mock('@/components/ui/scroll-area', async () => {
 vi.mock('react-virtuoso', async () => {
   const React = await import('react')
   return {
-    Virtuoso: (props: VirtuosoProps<ReactElement, unknown>) => {
+    Virtuoso: React.forwardRef<VirtuosoHandle, VirtuosoProps<ReactElement, unknown>>((props, ref) => {
       const {
         alignToBottom,
+        atBottomStateChange,
         customScrollParent,
         data = [],
         followOutput,
         initialTopMostItemIndex,
+        isScrolling,
         computeItemKey,
         itemContent
       } = props
       if (!computeItemKey || !itemContent) throw new TypeError('Virtuoso list callbacks are required')
       const keys = data.map((item, index) => computeItemKey(index, item, undefined))
-      virtuosoCalls.push({ alignToBottom, customScrollParent, data, followOutput, initialTopMostItemIndex, keys })
+      virtuosoCalls.push({
+        alignToBottom,
+        atBottomStateChange,
+        customScrollParent,
+        data,
+        followOutput,
+        initialTopMostItemIndex,
+        isScrolling,
+        keys
+      })
+      React.useImperativeHandle(ref, () => virtuosoHandle)
       useEffect(() => {
         virtuosoLifecycle.mounts += 1
         return () => {
@@ -62,10 +89,10 @@ vi.mock('react-virtuoso', async () => {
         'div',
         { 'data-testid': 'virtuoso' },
         data.map((item, index) =>
-          React.createElement(React.Fragment, { key: keys[index] }, itemContent(index, item, undefined))
+          React.createElement('div', { 'data-index': index, key: keys[index] }, itemContent(index, item, undefined))
         )
       )
-    }
+    })
   }
 })
 
@@ -119,10 +146,40 @@ const renderRows = (messages: readonly DisplayMessage[]) => {
   return virtuosoCalls.at(-1)!.keys
 }
 
+const testRows = (...ids: string[]) => ids.map((id) => createElement('div', { key: id }, id))
+const latestVirtuosoCall = () => {
+  const call = virtuosoCalls.at(-1)
+  if (!call) throw new TypeError('Virtuoso has not rendered')
+  return call
+}
+const reportBottom = (atBottom: boolean) => {
+  act(() => latestVirtuosoCall().atBottomStateChange?.(atBottom))
+}
+const reportScrolling = (isScrolling: boolean) => {
+  act(() => latestVirtuosoCall().isScrolling?.(isScrolling))
+}
+const beginManualScroll = (view: ReturnType<typeof render>) => {
+  act(() => view.getByTestId('scroll-area').dispatchEvent(new Event('wheel', { bubbles: true })))
+  reportScrolling(true)
+}
+const setBounds = (element: HTMLElement, top: number, bottom: number) =>
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    bottom,
+    height: bottom - top,
+    left: 0,
+    right: 0,
+    toJSON: () => ({}),
+    top,
+    width: 0,
+    x: 0,
+    y: top
+  })
+
 beforeEach(() => {
   virtuosoCalls.length = 0
   virtuosoLifecycle.mounts = 0
   virtuosoLifecycle.unmounts = 0
+  vi.clearAllMocks()
   scrollAreaRefControl.manual = false
   scrollAreaRefControl.ref = null
 })
@@ -192,13 +249,217 @@ describe('MessageList Virtuoso integration', () => {
     expect(virtuosoLifecycle).toEqual({ mounts: 2, unmounts: 1 })
   })
 
-  it('smooth-follows only when Virtuoso reports that the list was already at the bottom', () => {
-    renderRows([text('message', 1)])
+  it('makes the same tail-follow decision for received, sent, and synchronized child appends', () => {
+    let rows = testRows('initial')
+    const view = render(createElement(MessageList, null, rows))
 
-    const followOutput = virtuosoCalls.at(-1)?.followOutput
+    for (const source of ['received', 'sent', 'sync']) {
+      rows = [...rows, ...testRows(source)]
+      view.rerender(createElement(MessageList, null, rows))
+
+      const followOutput = latestVirtuosoCall().followOutput
+      expect(typeof followOutput).toBe('function')
+      expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
+      expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
+    }
+  })
+
+  it('does not follow a stable-key history prepend', () => {
+    const rows = testRows('current-1', 'current-2')
+    const view = render(createElement(MessageList, null, rows))
+
+    view.rerender(createElement(MessageList, null, [...testRows('history-1', 'history-2'), ...rows]))
+
+    const followOutput = latestVirtuosoCall().followOutput
+    expect(followOutput).toBe(false)
+    expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('shows the zero-count bottom action with the down-arrow icon and follows when activated', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    reportBottom(false)
+
+    const button = view.getByRole('button', { name: '回到底部' })
+    expect(button.textContent).toContain('回到底部')
+    expect(button.querySelector('svg.lucide-arrow-down')).not.toBeNull()
+
+    act(() => button.click())
+
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
+    reportBottom(true)
+    expect(view.queryByRole('button', { name: '回到底部' })).toBeNull()
+  })
+
+  it('pauses manual browsing, counts tail appends, and restores follow when the count action is activated', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+
+    view.rerender(createElement(MessageList, null, [...initialRows, ...testRows('new-message')]))
+
+    const followOutput = latestVirtuosoCall().followOutput
     expect(typeof followOutput).toBe('function')
-    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
-    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
+    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
+
+    const button = view.getByRole('button', { name: '1 条新消息' })
+    expect(button.textContent).toContain('1 条新消息')
+    act(() => button.click())
+
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
+    expect(view.getByRole('button', { name: '回到底部' })).not.toBeNull()
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
+  })
+
+  it('caps the pending tail count at 99+ in the follow action label', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+
+    view.rerender(
+      createElement(MessageList, null, [
+        ...initialRows,
+        ...Array.from({ length: 100 }, (_, index) => createElement('div', { key: `new-${index}` }, index))
+      ])
+    )
+
+    expect(view.getByRole('button', { name: '99+ 条新消息' })).not.toBeNull()
+    expect(view.queryByRole('button', { name: '回到底部' })).toBeNull()
+  })
+
+  it('waits for manual scrolling to end before following once at the bottom', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    reportBottom(true)
+    beginManualScroll(view)
+
+    reportBottom(true)
+    expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
+
+    reportScrolling(false)
+    expect(virtuosoHandle.autoscrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('waits for a non-bottom Virtuoso callback before replacing initial settlement', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    const item = view.container.querySelector<HTMLElement>('[data-index="0"]')!
+    Object.defineProperties(scrollParent, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 900, writable: true }
+    })
+    setBounds(scrollParent, 0, 100)
+    setBounds(item, 0, 50)
+
+    beginManualScroll(view)
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+
+    reportBottom(false)
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    reportBottom(false)
+
+    expect(virtuosoHandle.scrollTo).toHaveBeenCalledWith({ top: 100 })
+  })
+
+  it('requires a fully visible item instead of an earlier partial item to replace initial settlement', () => {
+    const view = render(createElement(MessageList, null, testRows('partial', 'full')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    const partialItem = view.container.querySelector<HTMLElement>('[data-index="0"]')!
+    const fullItem = view.container.querySelector<HTMLElement>('[data-index="1"]')!
+    Object.defineProperties(scrollParent, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 900, writable: true }
+    })
+    setBounds(scrollParent, 0, 100)
+    setBounds(partialItem, -20, 20)
+    setBounds(fullItem, 20, 80)
+
+    beginManualScroll(view)
+    reportBottom(false)
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    reportBottom(false)
+
+    expect(virtuosoHandle.scrollTo).toHaveBeenCalledWith({ top: 100 })
+  })
+
+  it('does not replace initial settlement when every visible item is partial', () => {
+    const view = render(createElement(MessageList, null, testRows('partial-top', 'partial-bottom')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    const topItem = view.container.querySelector<HTMLElement>('[data-index="0"]')!
+    const bottomItem = view.container.querySelector<HTMLElement>('[data-index="1"]')!
+    Object.defineProperties(scrollParent, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 900, writable: true }
+    })
+    setBounds(scrollParent, 0, 100)
+    setBounds(topItem, -20, 60)
+    setBounds(bottomItem, 60, 120)
+
+    beginManualScroll(view)
+    reportBottom(false)
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    reportBottom(false)
+
+    expect(virtuosoHandle.scrollTo).not.toHaveBeenCalled()
+  })
+
+  it('rebases one manually browsed head prepend without issuing a tail command', () => {
+    const rows = testRows('current-1', 'current-2', 'current-3')
+    const view = render(createElement(MessageList, null, rows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    const firstItem = view.container.querySelector<HTMLElement>('[data-index="0"]')!
+    const anchorItem = view.container.querySelector<HTMLElement>('[data-index="1"]')!
+    Object.defineProperties(scrollParent, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 900, writable: true }
+    })
+    setBounds(scrollParent, 0, 100)
+    setBounds(firstItem, -80, -20)
+    setBounds(anchorItem, 20, 80)
+
+    beginManualScroll(view)
+    reportBottom(false)
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    reportBottom(false)
+    expect(virtuosoHandle.scrollTo).toHaveBeenCalledWith({ top: 100 })
+    vi.clearAllMocks()
+
+    const pausedTailRows = [...rows, ...testRows('new-tail')]
+    view.rerender(createElement(MessageList, null, pausedTailRows))
+
+    const pausedTailFollowOutput = latestVirtuosoCall().followOutput
+    expect(typeof pausedTailFollowOutput).toBe('function')
+    expect((pausedTailFollowOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+
+    view.rerender(createElement(MessageList, null, [...testRows('history-1', 'history-2'), ...pausedTailRows]))
+
+    expect(latestVirtuosoCall().followOutput).toBe(false)
+    expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollBy).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollIntoView).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollTo).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({
+      index: 3,
+      align: 'start',
+      offset: -20,
+      behavior: 'auto'
+    })
   })
 
   it('keys text, singleton notice, and grouped notice rows from their stable projected identities', () => {

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -166,6 +166,18 @@ const latestVirtuosoCall = () => {
   return call
 }
 const reportBottom = (atBottom: boolean) => {
+  const call = latestVirtuosoCall()
+  const scrollParent = call.customScrollParent
+  if (scrollParent) {
+    if (atBottom) {
+      scrollParent.scrollTop = Math.max(0, scrollParent.scrollHeight - scrollParent.clientHeight)
+    } else if (scrollParent.scrollTop + scrollParent.clientHeight >= scrollParent.scrollHeight - 1) {
+      scrollParent.scrollTop = 0
+    }
+  }
+  act(() => call.atBottomStateChange?.(atBottom))
+}
+const reportStaleBottom = (atBottom: boolean) => {
   act(() => latestVirtuosoCall().atBottomStateChange?.(atBottom))
 }
 const reportScrolling = (isScrolling: boolean) => {
@@ -417,6 +429,22 @@ describe('MessageList Virtuoso integration', () => {
     expect((action as HTMLButtonElement).disabled).toBe(true)
   })
 
+  it('keeps a physical off-bottom viewport through a stale at-bottom callback and counts the next tail', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    reportBottom(true)
+
+    setScrollMetrics(scrollParent, 100, 1_000, 0)
+    reportStaleBottom(true)
+
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    view.rerender(createElement(MessageList, null, [...initialRows, ...testRows('new-message')]))
+
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
+  })
+
   it('shows only beyond half a viewport and preserves unread state across threshold crossings', () => {
     const initialRows = testRows('current')
     const view = render(createElement(MessageList, null, initialRows))
@@ -559,15 +587,16 @@ describe('MessageList Virtuoso integration', () => {
       scrollTop: { configurable: true, value: 900, writable: true }
     })
     setBounds(scrollParent, 0, 100)
-    setBounds(item, 0, 50)
+    setBounds(item, -20, 20)
 
     beginManualScroll(view)
     expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
 
+    scrollParent.scrollTop = 100
     reportBottom(false)
     expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
 
-    scrollParent.scrollTop = 100
+    setBounds(item, 0, 50)
     act(() => scrollParent.dispatchEvent(new Event('scroll')))
     reportBottom(false)
 
@@ -586,13 +615,14 @@ describe('MessageList Virtuoso integration', () => {
     })
     setBounds(scrollParent, 0, 100)
     setBounds(partialItem, -20, 20)
-    setBounds(fullItem, 20, 80)
+    setBounds(fullItem, 60, 120)
 
     beginManualScroll(view)
+    scrollParent.scrollTop = 100
     reportBottom(false)
     expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
 
-    scrollParent.scrollTop = 100
+    setBounds(fullItem, 20, 80)
     act(() => scrollParent.dispatchEvent(new Event('scroll')))
     reportBottom(false)
 
@@ -614,8 +644,8 @@ describe('MessageList Virtuoso integration', () => {
     setBounds(bottomItem, 60, 120)
 
     beginManualScroll(view)
-    reportBottom(false)
     scrollParent.scrollTop = 100
+    reportBottom(false)
     act(() => scrollParent.dispatchEvent(new Event('scroll')))
     reportBottom(false)
 
@@ -638,8 +668,8 @@ describe('MessageList Virtuoso integration', () => {
     setBounds(anchorItem, 20, 80)
 
     beginManualScroll(view)
-    reportBottom(false)
     scrollParent.scrollTop = 100
+    reportBottom(false)
     act(() => scrollParent.dispatchEvent(new Event('scroll')))
     reportBottom(false)
     expect(virtuosoHandle.scrollTo).toHaveBeenCalledWith({ top: 100 })
@@ -685,8 +715,8 @@ describe('MessageList Virtuoso integration', () => {
     setBounds(anchorItem, 20, 80)
 
     beginManualScroll(view)
-    reportBottom(false)
     scrollParent.scrollTop = 100
+    reportBottom(false)
     act(() => scrollParent.dispatchEvent(new Event('scroll')))
     reportBottom(false)
     vi.clearAllMocks()

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -18,6 +18,7 @@ interface VirtuosoCall {
   initialTopMostItemIndex?: VirtuosoProps<ReactElement, unknown>['initialTopMostItemIndex']
   isScrolling?: VirtuosoProps<ReactElement, unknown>['isScrolling']
   keys: (string | number | bigint)[]
+  totalListHeightChanged?: VirtuosoProps<ReactElement, unknown>['totalListHeightChanged']
 }
 
 const virtuosoCalls = vi.hoisted(() => [] as VirtuosoCall[])
@@ -37,12 +38,22 @@ vi.mock('@/components/ui/scroll-area', async () => {
   return {
     ScrollArea: ({ children, ref }: { children?: ReactElement; ref?: React.Ref<HTMLDivElement> }) => {
       scrollAreaRefControl.ref = ref ?? null
+      const setViewportRef = (node: HTMLDivElement | null) => {
+        if (node && !Object.getOwnPropertyDescriptor(node, 'clientHeight')) {
+          Object.defineProperties(node, {
+            clientHeight: { configurable: true, value: 100 },
+            scrollHeight: { configurable: true, value: 1_000 },
+            scrollTop: { configurable: true, value: 0, writable: true }
+          })
+        }
+        if (typeof ref === 'function') ref(node)
+      }
       return React.createElement(
         'div',
         { 'data-slot': 'scroll-area', 'data-testid': 'scroll-area' },
         React.createElement(
           'div',
-          { 'data-slot': 'scroll-area-viewport', ref: scrollAreaRefControl.manual ? undefined : ref },
+          { 'data-slot': 'scroll-area-viewport', ref: scrollAreaRefControl.manual ? undefined : setViewportRef },
           children
         ),
         React.createElement('div', { 'data-slot': 'scroll-area-scrollbar', 'data-testid': 'scrollbar' })
@@ -63,6 +74,7 @@ vi.mock('react-virtuoso', async () => {
         followOutput,
         initialTopMostItemIndex,
         isScrolling,
+        totalListHeightChanged,
         computeItemKey,
         itemContent
       } = props
@@ -76,6 +88,7 @@ vi.mock('react-virtuoso', async () => {
         followOutput,
         initialTopMostItemIndex,
         isScrolling,
+        totalListHeightChanged,
         keys
       })
       React.useImperativeHandle(ref, () => virtuosoHandle)
@@ -158,6 +171,9 @@ const reportBottom = (atBottom: boolean) => {
 const reportScrolling = (isScrolling: boolean) => {
   act(() => latestVirtuosoCall().isScrolling?.(isScrolling))
 }
+const reportTotalListHeightChanged = () => {
+  act(() => latestVirtuosoCall().totalListHeightChanged?.(1_000))
+}
 const beginManualScroll = (view: ReturnType<typeof render>) => {
   act(() => view.getByTestId('scroll-area').dispatchEvent(new Event('wheel', { bubbles: true })))
   reportScrolling(true)
@@ -174,6 +190,14 @@ const setBounds = (element: HTMLElement, top: number, bottom: number) =>
     x: 0,
     y: top
   })
+
+const setScrollMetrics = (element: HTMLElement, clientHeight: number, scrollHeight: number, scrollTop: number) => {
+  Object.defineProperties(element, {
+    clientHeight: { configurable: true, value: clientHeight },
+    scrollHeight: { configurable: true, value: scrollHeight },
+    scrollTop: { configurable: true, value: scrollTop, writable: true }
+  })
+}
 
 beforeEach(() => {
   virtuosoCalls.length = 0
@@ -275,19 +299,22 @@ describe('MessageList Virtuoso integration', () => {
     expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
   })
 
-  it('shows the zero-count bottom action with the down-arrow icon and follows when activated', () => {
+  it('shows the ArrowDown-only zero-count action and follows when activated', () => {
     const view = render(createElement(MessageList, null, testRows('current')))
     reportBottom(false)
 
-    const button = view.getByRole('button', { name: '回到底部' })
-    expect(button.textContent).toContain('回到底部')
+    const button = view.getByRole('button', { name: 'Scroll to latest messages' })
+    expect(button.textContent).toBe('')
     expect(button.querySelector('svg.lucide-arrow-down')).not.toBeNull()
+    expect(button.className).toContain('grid-cols-[auto_0fr]')
+    expect(button.className).toContain('left-1/2')
+    expect(button.className).toContain('-translate-x-1/2')
 
     act(() => button.click())
 
     expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
     reportBottom(true)
-    expect(view.queryByRole('button', { name: '回到底部' })).toBeNull()
+    expect(view.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
   })
 
   it('pauses manual browsing, counts tail appends, and restores follow when the count action is activated', () => {
@@ -303,12 +330,14 @@ describe('MessageList Virtuoso integration', () => {
     expect(typeof followOutput).toBe('function')
     expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
 
-    const button = view.getByRole('button', { name: '1 条新消息' })
-    expect(button.textContent).toContain('1 条新消息')
+    const button = view.getByRole('button', { name: '1 new message' })
+    expect(button.textContent).toContain('1 new message')
+    expect(button.className).toContain('grid-cols-[auto_1fr]')
+    expect(button.className).toContain('transition-[opacity,grid-template-columns,gap,padding]')
     act(() => button.click())
 
     expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
-    expect(view.getByRole('button', { name: '回到底部' })).not.toBeNull()
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
     expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
   })
 
@@ -321,15 +350,15 @@ describe('MessageList Virtuoso integration', () => {
 
     const rowsWithN1 = [...initialRows, ...testRows('n1')]
     view.rerender(createElement(MessageList, null, rowsWithN1))
-    act(() => view.getByRole('button', { name: '1 条新消息' }).click())
+    act(() => view.getByRole('button', { name: '1 new message' }).click())
     vi.clearAllMocks()
 
     view.rerender(createElement(MessageList, null, [...rowsWithN1, ...testRows('n2')]))
 
     expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
     expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe('smooth')
-    expect(view.queryByRole('button', { name: '1 条新消息' })).toBeNull()
-    expect(view.getByRole('button', { name: '回到底部' })).not.toBeNull()
+    expect(view.queryByRole('button', { name: '1 new message' })).toBeNull()
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
   })
 
   it('cancels click recovery when a manual departure occurs before N2', () => {
@@ -341,7 +370,7 @@ describe('MessageList Virtuoso integration', () => {
 
     const rowsWithN1 = [...initialRows, ...testRows('n1')]
     view.rerender(createElement(MessageList, null, rowsWithN1))
-    act(() => view.getByRole('button', { name: '1 条新消息' }).click())
+    act(() => view.getByRole('button', { name: '1 new message' }).click())
     vi.clearAllMocks()
 
     beginManualScroll(view)
@@ -350,7 +379,7 @@ describe('MessageList Virtuoso integration', () => {
 
     expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
     expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
-    expect(view.getByRole('button', { name: '1 条新消息' })).not.toBeNull()
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
   })
 
   it('caps the pending tail count at 99+ in the follow action label', () => {
@@ -367,15 +396,152 @@ describe('MessageList Virtuoso integration', () => {
       ])
     )
 
-    expect(view.getByRole('button', { name: '99+ 条新消息' })).not.toBeNull()
-    expect(view.queryByRole('button', { name: '回到底部' })).toBeNull()
+    expect(view.getByRole('button', { name: '99+ new messages' })).not.toBeNull()
+    expect(view.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+  })
+
+  it('keeps the action mounted through its fade exit while removing it from interaction', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    reportBottom(false)
+
+    const action = view.getByTestId('follow-latest-action')
+    expect(action.dataset.state).toBe('open')
+    expect(action.className).toContain('opacity-100')
+
+    reportBottom(true)
+
+    expect(view.getByTestId('follow-latest-action')).toBe(action)
+    expect(action.dataset.state).toBe('closed')
+    expect(action.className).toContain('opacity-0')
+    expect(action.getAttribute('aria-hidden')).toBe('true')
+    expect((action as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('shows only beyond half a viewport and preserves unread state across threshold crossings', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+    view.rerender(createElement(MessageList, null, [...initialRows, ...testRows('new-message')]))
+
+    setScrollMetrics(scrollParent, 100, 1_000, 851)
+    reportTotalListHeightChanged()
+    expect(view.queryByRole('button', { name: '1 new message' })).toBeNull()
+    expect(view.getByTestId('follow-latest-action').dataset.state).toBe('closed')
+
+    setScrollMetrics(scrollParent, 100, 1_000, 849)
+    reportTotalListHeightChanged()
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
+
+    setScrollMetrics(scrollParent, 100, 1_000, 851)
+    reportTotalListHeightChanged()
+    expect(view.queryByRole('button', { name: '1 new message' })).toBeNull()
+
+    setScrollMetrics(scrollParent, 100, 1_000, 849)
+    reportTotalListHeightChanged()
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
+  })
+
+  it('re-evaluates the half-screen threshold after a viewport resize without leaving a visible action', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    reportBottom(false)
+
+    setScrollMetrics(scrollParent, 500, 2_000, 1_000)
+    reportTotalListHeightChanged()
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    setScrollMetrics(scrollParent, 800, 2_000, 1_000)
+    reportTotalListHeightChanged()
+    expect(view.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+    expect(view.getByTestId('follow-latest-action').dataset.state).toBe('closed')
+  })
+
+  it('hides while the user scrolls downward, then restores after stopping away from the bottom', () => {
+    const view = render(createElement(MessageList, null, testRows('current')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    reportBottom(false)
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    beginManualScroll(view)
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    expect(view.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+
+    reportScrolling(false)
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    beginManualScroll(view)
+    scrollParent.scrollTop = 50
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    reportBottom(true)
+    expect(view.queryByRole('button', { name: 'Scroll to latest messages' })).toBeNull()
+  })
+
+  it('forces one current layout follow when a local send token and its projection commit together', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, { localSendToken: 0 }, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+    vi.clearAllMocks()
+
+    const rowsWithProjection = [...initialRows, ...testRows('local-projection')]
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, rowsWithProjection))
+
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
+
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, rowsWithProjection))
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps token-first local recovery current for the next layout without issuing a second command', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, { localSendToken: 0 }, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+    vi.clearAllMocks()
+
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, initialRows))
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, [...initialRows, ...testRows('local-projection')]))
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe('smooth')
+  })
+
+  it('does not force a projection-first received tail and consumes each newer local send token once', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, { localSendToken: 0 }, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+    vi.clearAllMocks()
+
+    const receivedRows = [...initialRows, ...testRows('same-user-tail-sync')]
+    view.rerender(createElement(MessageList, { localSendToken: 0 }, receivedRows))
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
+
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, receivedRows))
+    view.rerender(createElement(MessageList, { localSendToken: 2 }, receivedRows))
+    view.rerender(createElement(MessageList, { localSendToken: 1 }, receivedRows))
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(2)
   })
 
   it('waits for manual scrolling to end before following once at the bottom', () => {
     const view = render(createElement(MessageList, null, testRows('current')))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
     reportBottom(true)
     beginManualScroll(view)
 
+    scrollParent.scrollTop = scrollParent.scrollHeight - scrollParent.clientHeight
     reportBottom(true)
     expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
 
@@ -532,7 +698,7 @@ describe('MessageList Virtuoso integration', () => {
     const followOutput = latestVirtuosoCall().followOutput
     expect(typeof followOutput).toBe('function')
     expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
-    expect(view.getByRole('button', { name: '1 条新消息' })).not.toBeNull()
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
     expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
     expect(virtuosoHandle.scrollBy).not.toHaveBeenCalled()
     expect(virtuosoHandle.scrollIntoView).not.toHaveBeenCalled()

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -309,7 +309,48 @@ describe('MessageList Virtuoso integration', () => {
 
     expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({ index: 'LAST', align: 'end', behavior: 'smooth' })
     expect(view.getByRole('button', { name: '回到底部' })).not.toBeNull()
-    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
+  })
+
+  it('keeps click recovery current when N2 appends before it reaches the bottom', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+
+    const rowsWithN1 = [...initialRows, ...testRows('n1')]
+    view.rerender(createElement(MessageList, null, rowsWithN1))
+    act(() => view.getByRole('button', { name: '1 条新消息' }).click())
+    vi.clearAllMocks()
+
+    view.rerender(createElement(MessageList, null, [...rowsWithN1, ...testRows('n2')]))
+
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe('smooth')
+    expect(view.queryByRole('button', { name: '1 条新消息' })).toBeNull()
+    expect(view.getByRole('button', { name: '回到底部' })).not.toBeNull()
+  })
+
+  it('cancels click recovery when a manual departure occurs before N2', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    reportBottom(true)
+    beginManualScroll(view)
+    reportBottom(false)
+
+    const rowsWithN1 = [...initialRows, ...testRows('n1')]
+    view.rerender(createElement(MessageList, null, rowsWithN1))
+    act(() => view.getByRole('button', { name: '1 条新消息' }).click())
+    vi.clearAllMocks()
+
+    beginManualScroll(view)
+    reportBottom(false)
+    view.rerender(createElement(MessageList, null, [...rowsWithN1, ...testRows('n2')]))
+
+    expect(virtuosoHandle.scrollToIndex).not.toHaveBeenCalled()
+    expect((latestVirtuosoCall().followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
+    expect(view.getByRole('button', { name: '1 条新消息' })).not.toBeNull()
   })
 
   it('caps the pending tail count at 99+ in the follow action label', () => {
@@ -449,6 +490,49 @@ describe('MessageList Virtuoso integration', () => {
     view.rerender(createElement(MessageList, null, [...testRows('history-1', 'history-2'), ...pausedTailRows]))
 
     expect(latestVirtuosoCall().followOutput).toBe(false)
+    expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollBy).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollIntoView).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollTo).not.toHaveBeenCalled()
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledTimes(1)
+    expect(virtuosoHandle.scrollToIndex).toHaveBeenCalledWith({
+      index: 3,
+      align: 'start',
+      offset: -20,
+      behavior: 'auto'
+    })
+  })
+
+  it('rebases and counts one canonical paused head-plus-tail snapshot without a competing command', () => {
+    const rows = testRows('current-1', 'current-2', 'current-3')
+    const view = render(createElement(MessageList, null, rows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    const firstItem = view.container.querySelector<HTMLElement>('[data-index="0"]')!
+    const anchorItem = view.container.querySelector<HTMLElement>('[data-index="1"]')!
+    Object.defineProperties(scrollParent, {
+      clientHeight: { configurable: true, value: 100 },
+      scrollHeight: { configurable: true, value: 1_000 },
+      scrollTop: { configurable: true, value: 900, writable: true }
+    })
+    setBounds(scrollParent, 0, 100)
+    setBounds(firstItem, -80, -20)
+    setBounds(anchorItem, 20, 80)
+
+    beginManualScroll(view)
+    reportBottom(false)
+    scrollParent.scrollTop = 100
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    reportBottom(false)
+    vi.clearAllMocks()
+
+    view.rerender(
+      createElement(MessageList, null, [...testRows('history-1', 'history-2'), ...rows, ...testRows('new-tail')])
+    )
+
+    const followOutput = latestVirtuosoCall().followOutput
+    expect(typeof followOutput).toBe('function')
+    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
+    expect(view.getByRole('button', { name: '1 条新消息' })).not.toBeNull()
     expect(virtuosoHandle.autoscrollToBottom).not.toHaveBeenCalled()
     expect(virtuosoHandle.scrollBy).not.toHaveBeenCalled()
     expect(virtuosoHandle.scrollIntoView).not.toHaveBeenCalled()

--- a/src/app/content/components/message-list.test.ts
+++ b/src/app/content/components/message-list.test.ts
@@ -288,14 +288,18 @@ describe('MessageList Virtuoso integration', () => {
   it('makes the same tail-follow decision for received, sent, and synchronized child appends', () => {
     let rows = testRows('initial')
     const view = render(createElement(MessageList, null, rows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
 
     for (const source of ['received', 'sent', 'sync']) {
+      reportBottom(true)
       rows = [...rows, ...testRows(source)]
       view.rerender(createElement(MessageList, null, rows))
 
       const followOutput = latestVirtuosoCall().followOutput
       expect(typeof followOutput).toBe('function')
       expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe('smooth')
+
+      scrollParent.scrollTop = 0
       expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(false)).toBe(false)
     }
   })
@@ -442,6 +446,24 @@ describe('MessageList Virtuoso integration', () => {
 
     view.rerender(createElement(MessageList, null, [...initialRows, ...testRows('new-message')]))
 
+    expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
+  })
+
+  it('uses the physical bottom snapshot for a tail append without an at-bottom callback', () => {
+    const initialRows = testRows('current')
+    const view = render(createElement(MessageList, null, initialRows))
+    const scrollParent = latestVirtuosoCall().customScrollParent!
+    reportBottom(true)
+
+    setScrollMetrics(scrollParent, 100, 1_000, 0)
+    act(() => scrollParent.dispatchEvent(new Event('scroll')))
+    expect(view.getByRole('button', { name: 'Scroll to latest messages' })).not.toBeNull()
+
+    view.rerender(createElement(MessageList, null, [...initialRows, ...testRows('new-message')]))
+
+    const followOutput = latestVirtuosoCall().followOutput
+    expect(typeof followOutput).toBe('function')
+    expect((followOutput as (isAtBottom: boolean) => false | 'smooth')(true)).toBe(false)
     expect(view.getByRole('button', { name: '1 new message' })).not.toBeNull()
   })
 

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -199,6 +199,15 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
     []
   )
 
+  const getAtBottomSnapshot = useCallback(
+    (reportedAtBottom: boolean) => {
+      const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : reportedAtBottom
+      atBottomRef.current = atBottom
+      return atBottom
+    },
+    [scrollParentRef]
+  )
+
   const clearInitialScrollCancellation = useCallback(() => {
     initialScrollCancellationPendingRef.current = false
     initialScrollCancellationPassedHeadRef.current = false
@@ -279,9 +288,10 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
   useLayoutEffect(() => {
     if (isNewTailAppend) {
       lastTailItemKeysRef.current = itemKeys
+      const atBottom = getAtBottomSnapshot(atBottomRef.current)
       if (latestRecoveryRef.current) {
         clearNewMessageCount()
-      } else if (!canFollowLatest(atBottomRef.current)) {
+      } else if (!canFollowLatest(atBottom)) {
         newMessageCountRef.current += tailCount
         setNewMessageCount(newMessageCountRef.current)
       }
@@ -321,6 +331,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
     clearInitialScrollCancellation,
     clearNewMessageCount,
     firstItemIndex,
+    getAtBottomSnapshot,
     headCount,
     hasChildren,
     isHeadPrepend,
@@ -396,8 +407,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
 
   const handleAtBottomStateChange = useCallback(
     (reportedAtBottom: boolean) => {
-      const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : reportedAtBottom
-      atBottomRef.current = atBottom
+      const atBottom = getAtBottomSnapshot(reportedAtBottom)
       if (!atBottom) {
         acknowledgeManualDeparture()
         updateViewportActionState(false)
@@ -418,6 +428,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
       clearHeadAnchor,
       clearInitialScrollCancellation,
       clearNewMessageCount,
+      getAtBottomSnapshot,
       updateViewportActionState
     ]
   )
@@ -476,9 +487,13 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
   }, [handleAtBottomStateChange, scrollParentRef, updateViewportActionState])
 
   const handleFollowOutput = useCallback(
-    (atBottom: boolean) =>
-      isTailAppend && ((isNewTailAppend && latestRecoveryRef.current) || canFollowLatest(atBottom)) ? 'smooth' : false,
-    [canFollowLatest, isNewTailAppend, isTailAppend]
+    (reportedAtBottom: boolean) => {
+      const atBottom = getAtBottomSnapshot(reportedAtBottom)
+      return isTailAppend && ((isNewTailAppend && latestRecoveryRef.current) || canFollowLatest(atBottom))
+        ? 'smooth'
+        : false
+    },
+    [canFollowLatest, getAtBottomSnapshot, isNewTailAppend, isTailAppend]
   )
 
   const handleFollowLatest = useCallback(() => {

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -1,7 +1,8 @@
-import { useState, type FC, type ReactElement } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type FC, type ReactElement } from 'react'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Virtuoso } from 'react-virtuoso'
+import { ArrowDownIcon } from 'lucide-react'
+import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
 
 export interface MessageListProps {
   children?: ReactElement[] | null
@@ -12,26 +13,378 @@ const itemKey = (_: number, item: ReactElement) => {
   return item.key
 }
 
+type ChildUpdate =
+  | { kind: 'initial' | 'none' | 'replace' }
+  | {
+      kind: 'head' | 'tail'
+      count: number
+    }
+
+type ScrollCommand =
+  | { kind: 'cancel-initial'; top: number }
+  | { kind: 'follow-bottom' | 'follow-latest' }
+  | { index: number; kind: 'head-rebase'; offset: number }
+
+const hasPrefix = (prefix: readonly string[], values: readonly string[]) =>
+  prefix.length <= values.length && prefix.every((value, index) => values[index] === value)
+
+const hasSuffix = (suffix: readonly string[], values: readonly string[]) =>
+  suffix.length <= values.length &&
+  suffix.every((value, index) => values[values.length - suffix.length + index] === value)
+
+const hasSameItems = (left: readonly string[], right: readonly string[]) =>
+  left.length === right.length && left.every((value, index) => value === right[index])
+
+const getVisibleItemLocation = (scrollParent: HTMLElement) => {
+  const viewportBounds = scrollParent.getBoundingClientRect()
+  const item = Array.from(scrollParent.querySelectorAll<HTMLElement>('[data-index]')).find((item) => {
+    const bounds = item.getBoundingClientRect()
+    return bounds.top >= viewportBounds.top && bounds.bottom <= viewportBounds.bottom
+  })
+  const index = Number(item?.dataset.index)
+  if (!item || !Number.isInteger(index)) return null
+
+  return { index, offset: viewportBounds.top - item.getBoundingClientRect().top }
+}
+
+type HeadAnchor = {
+  index: number
+  key: string
+  offset: number
+}
+
+const getHeadAnchor = (scrollParent: HTMLElement, itemKeys: readonly string[]): HeadAnchor | null => {
+  const viewportBounds = scrollParent.getBoundingClientRect()
+  const item = Array.from(scrollParent.querySelectorAll<HTMLElement>('[data-index]')).find((item) => {
+    const bounds = item.getBoundingClientRect()
+    return bounds.top < viewportBounds.bottom && bounds.bottom > viewportBounds.top
+  })
+  const index = Number(item?.dataset.index)
+  const key = itemKeys[index]
+  if (!item || !Number.isInteger(index) || key === undefined) return null
+
+  return { index, key, offset: viewportBounds.top - item.getBoundingClientRect().top }
+}
+
+const isViewportAtBottom = (scrollParent: HTMLElement) =>
+  scrollParent.scrollTop + scrollParent.clientHeight >= scrollParent.scrollHeight - 1
+
+const getChildUpdate = (previous: readonly string[] | null, current: readonly string[]): ChildUpdate => {
+  if (previous === null) return { kind: 'initial' }
+  if (hasSameItems(previous, current)) return { kind: 'none' }
+  if (current.length > previous.length && hasPrefix(previous, current)) {
+    return { kind: 'tail', count: current.length - previous.length }
+  }
+  if (current.length > previous.length && hasSuffix(previous, current)) {
+    return { kind: 'head', count: current.length - previous.length }
+  }
+  return { kind: 'replace' }
+}
+
+const INITIAL_FIRST_ITEM_INDEX = 1_000_000
+const INITIAL_TOP_MOST_ITEM_INDEX = { index: 'LAST' as const, align: 'end' as const }
+
 const MessageList: FC<MessageListProps> = ({ children }) => {
   const [scrollParentRef, setScrollParentRef] = useState<HTMLDivElement | null>(null)
+  const [initialTopMostItemIndex, setInitialTopMostItemIndex] = useState<
+    typeof INITIAL_TOP_MOST_ITEM_INDEX | undefined
+  >(INITIAL_TOP_MOST_ITEM_INDEX)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+  const [newMessageCount, setNewMessageCount] = useState(0)
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null)
+  const previousItemKeysRef = useRef<readonly string[] | null>(null)
+  const firstItemIndexRef = useRef(INITIAL_FIRST_ITEM_INDEX)
+  const lastHeadItemKeysRef = useRef<readonly string[] | null>(null)
+  const atBottomRef = useRef(true)
+  const manualScrollIntentRef = useRef(false)
+  const manualScrollActiveRef = useRef(false)
+  const manualScrollPausedRef = useRef(false)
+  const initialScrollCancellationEligibleRef = useRef(true)
+  const initialScrollCancellationPendingRef = useRef(false)
+  const initialScrollCancellationPassedHeadRef = useRef(false)
+  const headAnchorRef = useRef<HeadAnchor | null>(null)
+  const newMessageCountRef = useRef(0)
+  const hasChildren = children !== null && children !== undefined
+  const itemKeys = useMemo(
+    () => (hasChildren ? children.map((item, index) => itemKey(index, item)) : []),
+    [children, hasChildren]
+  )
+  const itemKeysRef = useRef<readonly string[]>(itemKeys)
+  const childUpdate = useMemo(() => getChildUpdate(previousItemKeysRef.current, itemKeys), [itemKeys])
+  const isHeadPrepend = childUpdate.kind === 'head' && lastHeadItemKeysRef.current !== itemKeys
+  const firstItemIndex = isHeadPrepend ? firstItemIndexRef.current - childUpdate.count : firstItemIndexRef.current
+
+  const clearNewMessageCount = useCallback(() => {
+    if (newMessageCountRef.current === 0) return
+    newMessageCountRef.current = 0
+    setNewMessageCount(0)
+  }, [])
+
+  const promoteManualScroll = useCallback(() => {
+    if (!manualScrollIntentRef.current) return
+    manualScrollIntentRef.current = false
+    manualScrollActiveRef.current = true
+  }, [])
+
+  const canFollowLatest = useCallback(
+    (atBottom: boolean) => atBottom && !manualScrollActiveRef.current && !manualScrollPausedRef.current,
+    []
+  )
+
+  const clearInitialScrollCancellation = useCallback(() => {
+    initialScrollCancellationPendingRef.current = false
+    initialScrollCancellationPassedHeadRef.current = false
+  }, [])
+
+  const clearHeadAnchor = useCallback(() => {
+    headAnchorRef.current = null
+  }, [])
+
+  const runScrollCommand = useCallback((command: ScrollCommand) => {
+    const handle = virtuosoRef.current
+    if (!handle) return
+
+    switch (command.kind) {
+      case 'cancel-initial':
+        handle.scrollTo({ top: command.top })
+        return
+      case 'follow-bottom':
+        handle.autoscrollToBottom()
+        return
+      case 'follow-latest':
+        handle.scrollToIndex({ index: 'LAST', align: 'end', behavior: 'smooth' })
+        return
+      case 'head-rebase':
+        handle.scrollToIndex({ index: command.index, align: 'start', offset: command.offset, behavior: 'auto' })
+    }
+  }, [])
+
+  const captureInitialScrollCancellation = useCallback(() => {
+    if (!scrollParentRef || !initialScrollCancellationPendingRef.current) return
+
+    if (initialScrollCancellationPassedHeadRef.current) return
+
+    if (isViewportAtBottom(scrollParentRef)) return
+
+    if (!getVisibleItemLocation(scrollParentRef)) return
+
+    initialScrollCancellationPendingRef.current = false
+    runScrollCommand({ kind: 'cancel-initial', top: scrollParentRef.scrollTop })
+    clearInitialScrollCancellation()
+  }, [clearInitialScrollCancellation, runScrollCommand, scrollParentRef])
+
+  const captureHeadAnchor = useCallback(() => {
+    if (!scrollParentRef || !manualScrollPausedRef.current || isViewportAtBottom(scrollParentRef)) return
+
+    headAnchorRef.current = getHeadAnchor(scrollParentRef, itemKeysRef.current)
+  }, [scrollParentRef])
+
+  const acknowledgeManualDeparture = useCallback(() => {
+    if (!scrollParentRef || isViewportAtBottom(scrollParentRef)) return
+
+    promoteManualScroll()
+    if (!manualScrollActiveRef.current) return
+
+    atBottomRef.current = false
+    manualScrollPausedRef.current = true
+    setIsAtBottom(false)
+    captureHeadAnchor()
+    captureInitialScrollCancellation()
+  }, [captureHeadAnchor, captureInitialScrollCancellation, promoteManualScroll, scrollParentRef])
+
+  useLayoutEffect(() => {
+    itemKeysRef.current = itemKeys
+  }, [itemKeys])
+
+  useLayoutEffect(() => {
+    if (childUpdate.kind === 'tail' && !canFollowLatest(atBottomRef.current)) {
+      newMessageCountRef.current += childUpdate.count
+      setNewMessageCount(newMessageCountRef.current)
+    }
+    if (isHeadPrepend) {
+      firstItemIndexRef.current = firstItemIndex
+      lastHeadItemKeysRef.current = itemKeys
+      if (initialScrollCancellationPendingRef.current) {
+        if (initialScrollCancellationPassedHeadRef.current) {
+          clearInitialScrollCancellation()
+        } else {
+          initialScrollCancellationPassedHeadRef.current = true
+        }
+      }
+      const headAnchor = headAnchorRef.current
+      clearHeadAnchor()
+      if (headAnchor) {
+        const index = headAnchor.index + childUpdate.count
+        if (itemKeys[index] === headAnchor.key) {
+          runScrollCommand({ kind: 'head-rebase', index, offset: headAnchor.offset })
+        }
+      }
+    }
+    if (childUpdate.kind === 'tail' || childUpdate.kind === 'replace') {
+      clearInitialScrollCancellation()
+    }
+    if (childUpdate.kind === 'replace') {
+      clearHeadAnchor()
+    }
+    previousItemKeysRef.current = hasChildren ? itemKeys : null
+  }, [
+    canFollowLatest,
+    childUpdate,
+    clearHeadAnchor,
+    clearInitialScrollCancellation,
+    firstItemIndex,
+    hasChildren,
+    isHeadPrepend,
+    itemKeys,
+    runScrollCommand
+  ])
+
+  useLayoutEffect(() => {
+    if (!scrollParentRef) return
+
+    const scrollArea = scrollParentRef.closest<HTMLElement>('[data-slot="scroll-area"]') ?? scrollParentRef
+    const markManualScrollIntent = () => {
+      if (initialScrollCancellationEligibleRef.current) {
+        initialScrollCancellationEligibleRef.current = false
+        initialScrollCancellationPendingRef.current = true
+        setInitialTopMostItemIndex(undefined)
+      }
+      manualScrollIntentRef.current = true
+    }
+    const markScrollbarScrollIntent = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Element && target.closest('[data-slot="scroll-area-scrollbar"]')) {
+        markManualScrollIntent()
+      }
+    }
+
+    scrollArea.addEventListener('wheel', markManualScrollIntent, { passive: true })
+    scrollArea.addEventListener('touchmove', markManualScrollIntent, { passive: true })
+    scrollArea.addEventListener('pointerdown', markScrollbarScrollIntent)
+    const handleScroll = () => {
+      promoteManualScroll()
+      acknowledgeManualDeparture()
+    }
+
+    scrollParentRef.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      scrollArea.removeEventListener('wheel', markManualScrollIntent)
+      scrollArea.removeEventListener('touchmove', markManualScrollIntent)
+      scrollArea.removeEventListener('pointerdown', markScrollbarScrollIntent)
+      scrollParentRef.removeEventListener('scroll', handleScroll)
+      clearInitialScrollCancellation()
+      clearHeadAnchor()
+    }
+  }, [
+    acknowledgeManualDeparture,
+    clearHeadAnchor,
+    clearInitialScrollCancellation,
+    promoteManualScroll,
+    scrollParentRef
+  ])
+
+  const handleAtBottomStateChange = useCallback(
+    (atBottom: boolean) => {
+      atBottomRef.current = atBottom
+      setIsAtBottom(atBottom)
+      if (!atBottom) {
+        acknowledgeManualDeparture()
+        return
+      }
+      clearInitialScrollCancellation()
+      clearHeadAnchor()
+      if (manualScrollActiveRef.current) return
+
+      manualScrollPausedRef.current = false
+      clearNewMessageCount()
+    },
+    [acknowledgeManualDeparture, clearHeadAnchor, clearInitialScrollCancellation, clearNewMessageCount]
+  )
+
+  const handleIsScrolling = useCallback(
+    (isScrolling: boolean) => {
+      if (isScrolling) {
+        promoteManualScroll()
+        acknowledgeManualDeparture()
+        return
+      }
+      manualScrollIntentRef.current = false
+      if (!manualScrollActiveRef.current) return
+
+      manualScrollActiveRef.current = false
+      const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : atBottomRef.current
+      if (!atBottom) return
+
+      atBottomRef.current = true
+      setIsAtBottom(true)
+      manualScrollPausedRef.current = false
+      clearHeadAnchor()
+      clearNewMessageCount()
+      runScrollCommand({ kind: 'follow-bottom' })
+    },
+    [
+      acknowledgeManualDeparture,
+      clearHeadAnchor,
+      clearNewMessageCount,
+      promoteManualScroll,
+      runScrollCommand,
+      scrollParentRef
+    ]
+  )
+
+  const handleFollowOutput = useCallback(
+    (atBottom: boolean) => (childUpdate.kind === 'tail' && canFollowLatest(atBottom) ? 'smooth' : false),
+    [canFollowLatest, childUpdate.kind]
+  )
+
+  const handleFollowLatest = useCallback(() => {
+    manualScrollIntentRef.current = false
+    manualScrollActiveRef.current = false
+    manualScrollPausedRef.current = false
+    clearInitialScrollCancellation()
+    clearHeadAnchor()
+    clearNewMessageCount()
+    runScrollCommand({ kind: 'follow-latest' })
+  }, [clearHeadAnchor, clearInitialScrollCancellation, clearNewMessageCount, runScrollCommand])
+
+  const followActionLabel =
+    newMessageCount === 0 ? '回到底部' : `${newMessageCount > 99 ? '99+' : newMessageCount} 条新消息`
 
   return (
-    <ScrollArea ref={setScrollParentRef} className="dark:bg-slate-900">
-      {children !== null && children !== undefined && scrollParentRef ? (
-        <Virtuoso
-          defaultItemHeight={108}
-          increaseViewportBy={200}
-          overscan={200}
-          followOutput={(isAtBottom: boolean) => (isAtBottom ? 'smooth' : false)}
-          initialTopMostItemIndex={{ index: 'LAST', align: 'end' }}
-          data={children}
-          customScrollParent={scrollParentRef}
-          computeItemKey={itemKey}
-          skipAnimationFrameInResizeObserver
-          itemContent={(_, item) => item}
-        />
+    <div className="relative min-h-0">
+      <ScrollArea ref={setScrollParentRef} className="size-full dark:bg-slate-900">
+        {hasChildren && scrollParentRef ? (
+          <Virtuoso
+            ref={virtuosoRef}
+            defaultItemHeight={108}
+            increaseViewportBy={200}
+            overscan={200}
+            atBottomStateChange={handleAtBottomStateChange}
+            isScrolling={handleIsScrolling}
+            followOutput={childUpdate.kind === 'tail' ? handleFollowOutput : false}
+            firstItemIndex={firstItemIndex}
+            initialTopMostItemIndex={initialTopMostItemIndex}
+            data={children}
+            customScrollParent={scrollParentRef}
+            computeItemKey={itemKey}
+            skipAnimationFrameInResizeObserver
+            itemContent={(_, item) => item}
+          />
+        ) : null}
+      </ScrollArea>
+      {hasChildren && scrollParentRef && !isAtBottom ? (
+        <button
+          type="button"
+          aria-label={followActionLabel}
+          title={followActionLabel}
+          className="bg-secondary absolute right-3 bottom-3 z-10 inline-flex h-7 items-center gap-x-1.5 rounded-full px-2 text-xs font-medium text-slate-500 shadow-sm hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+          onClick={handleFollowLatest}
+        >
+          <ArrowDownIcon size={14} aria-hidden="true" />
+          <span>{followActionLabel}</span>
+        </button>
       ) : null}
-    </ScrollArea>
+    </div>
   )
 }
 

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState, type FC, type ReactElement } from 'react'
 
 import { ScrollArea } from '@/components/ui/scroll-area'
+import NumberFlow from '@number-flow/react'
 import { ArrowDownIcon } from 'lucide-react'
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso'
+import { cn } from '@/utils'
 
 export interface MessageListProps {
   children?: ReactElement[] | null
+  localSendToken?: number
 }
 
 const itemKey = (_: number, item: ReactElement) => {
@@ -58,6 +61,12 @@ type HeadAnchor = {
   offset: number
 }
 
+type ViewportActionState = {
+  isAtBottom: boolean
+  isBeyondHalfScreen: boolean
+  isManualScrollDown: boolean
+}
+
 const getHeadAnchor = (scrollParent: HTMLElement, itemKeys: readonly string[]): HeadAnchor | null => {
   const viewportBounds = scrollParent.getBoundingClientRect()
   const item = Array.from(scrollParent.querySelectorAll<HTMLElement>('[data-index]')).find((item) => {
@@ -73,6 +82,19 @@ const getHeadAnchor = (scrollParent: HTMLElement, itemKeys: readonly string[]): 
 
 const isViewportAtBottom = (scrollParent: HTMLElement) =>
   scrollParent.scrollTop + scrollParent.clientHeight >= scrollParent.scrollHeight - 1
+
+const getViewportActionState = (
+  scrollParent: HTMLElement,
+  isAtBottom: boolean,
+  isManualScrollDown: boolean
+): ViewportActionState => {
+  const distanceFromBottom = Math.max(0, scrollParent.scrollHeight - scrollParent.clientHeight - scrollParent.scrollTop)
+  return {
+    isAtBottom,
+    isBeyondHalfScreen: scrollParent.clientHeight > 0 && distanceFromBottom > scrollParent.clientHeight * 0.5,
+    isManualScrollDown
+  }
+}
 
 const getChildUpdate = (previous: readonly string[] | null, current: readonly string[]): ChildUpdate => {
   if (previous === null) return { kind: 'initial' }
@@ -97,12 +119,16 @@ const getChildUpdate = (previous: readonly string[] | null, current: readonly st
 const INITIAL_FIRST_ITEM_INDEX = 1_000_000
 const INITIAL_TOP_MOST_ITEM_INDEX = { index: 'LAST' as const, align: 'end' as const }
 
-const MessageList: FC<MessageListProps> = ({ children }) => {
+const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => {
   const [scrollParentRef, setScrollParentRef] = useState<HTMLDivElement | null>(null)
   const [initialTopMostItemIndex, setInitialTopMostItemIndex] = useState<
     typeof INITIAL_TOP_MOST_ITEM_INDEX | undefined
   >(INITIAL_TOP_MOST_ITEM_INDEX)
-  const [isAtBottom, setIsAtBottom] = useState(true)
+  const [viewportActionState, setViewportActionState] = useState<ViewportActionState>({
+    isAtBottom: true,
+    isBeyondHalfScreen: false,
+    isManualScrollDown: false
+  })
   const [newMessageCount, setNewMessageCount] = useState(0)
   const virtuosoRef = useRef<VirtuosoHandle | null>(null)
   const previousItemKeysRef = useRef<readonly string[] | null>(null)
@@ -113,12 +139,16 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   const manualScrollIntentRef = useRef(false)
   const manualScrollActiveRef = useRef(false)
   const manualScrollPausedRef = useRef(false)
+  const manualScrollDownRef = useRef(false)
+  const lastScrollTopRef = useRef(0)
+  const pendingProgrammaticScrollRef = useRef(false)
   const initialScrollCancellationEligibleRef = useRef(true)
   const initialScrollCancellationPendingRef = useRef(false)
   const initialScrollCancellationPassedHeadRef = useRef(false)
   const headAnchorRef = useRef<HeadAnchor | null>(null)
   const latestRecoveryRef = useRef(false)
   const newMessageCountRef = useRef(0)
+  const lastLocalSendTokenRef = useRef(localSendToken)
   const hasChildren = children !== null && children !== undefined
   const itemKeys = useMemo(
     () => (hasChildren ? children.map((item, index) => itemKey(index, item)) : []),
@@ -140,6 +170,22 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     newMessageCountRef.current = 0
     setNewMessageCount(0)
   }, [])
+
+  const updateViewportActionState = useCallback(
+    (isAtBottom: boolean = scrollParentRef ? isViewportAtBottom(scrollParentRef) : atBottomRef.current) => {
+      if (!scrollParentRef) return
+
+      const nextState = getViewportActionState(scrollParentRef, isAtBottom, manualScrollDownRef.current)
+      setViewportActionState((currentState) =>
+        currentState.isAtBottom === nextState.isAtBottom &&
+        currentState.isBeyondHalfScreen === nextState.isBeyondHalfScreen &&
+        currentState.isManualScrollDown === nextState.isManualScrollDown
+          ? currentState
+          : nextState
+      )
+    },
+    [scrollParentRef]
+  )
 
   const promoteManualScroll = useCallback(() => {
     if (!manualScrollIntentRef.current) return
@@ -181,6 +227,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
         handle.scrollToIndex({ index: 'LAST', align: 'end', behavior: 'smooth' })
         return
       case 'head-rebase':
+        pendingProgrammaticScrollRef.current = true
         handle.scrollToIndex({ index: command.index, align: 'start', offset: command.offset, behavior: 'auto' })
     }
   }, [])
@@ -214,7 +261,6 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     cancelLatestRecovery()
     atBottomRef.current = false
     manualScrollPausedRef.current = true
-    setIsAtBottom(false)
     captureHeadAnchor()
     captureInitialScrollCancellation()
   }, [cancelLatestRecovery, captureHeadAnchor, captureInitialScrollCancellation, promoteManualScroll, scrollParentRef])
@@ -222,6 +268,13 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   useLayoutEffect(() => {
     itemKeysRef.current = itemKeys
   }, [itemKeys])
+
+  useLayoutEffect(() => {
+    if (!scrollParentRef) return
+
+    lastScrollTopRef.current = scrollParentRef.scrollTop
+    updateViewportActionState(atBottomRef.current)
+  }, [scrollParentRef, updateViewportActionState])
 
   useLayoutEffect(() => {
     if (isNewTailAppend) {
@@ -289,6 +342,9 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
         initialScrollCancellationPendingRef.current = true
         setInitialTopMostItemIndex(undefined)
       }
+      lastScrollTopRef.current = scrollParentRef.scrollTop
+      manualScrollDownRef.current = false
+      pendingProgrammaticScrollRef.current = false
       manualScrollIntentRef.current = true
     }
     const markScrollbarScrollIntent = (event: PointerEvent) => {
@@ -302,8 +358,20 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     scrollArea.addEventListener('touchmove', markManualScrollIntent, { passive: true })
     scrollArea.addEventListener('pointerdown', markScrollbarScrollIntent)
     const handleScroll = () => {
+      const nextScrollTop = scrollParentRef.scrollTop
+      if (pendingProgrammaticScrollRef.current) {
+        pendingProgrammaticScrollRef.current = false
+        manualScrollDownRef.current = false
+        lastScrollTopRef.current = nextScrollTop
+        updateViewportActionState(isViewportAtBottom(scrollParentRef))
+        return
+      }
+
       promoteManualScroll()
+      manualScrollDownRef.current = manualScrollActiveRef.current && nextScrollTop > lastScrollTopRef.current
+      lastScrollTopRef.current = nextScrollTop
       acknowledgeManualDeparture()
+      updateViewportActionState(isViewportAtBottom(scrollParentRef))
     }
 
     scrollParentRef.addEventListener('scroll', handleScroll, { passive: true })
@@ -322,31 +390,34 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     clearHeadAnchor,
     clearInitialScrollCancellation,
     promoteManualScroll,
-    scrollParentRef
+    scrollParentRef,
+    updateViewportActionState
   ])
 
   const handleAtBottomStateChange = useCallback(
     (atBottom: boolean) => {
       atBottomRef.current = atBottom
-      setIsAtBottom(atBottom)
       if (!atBottom) {
         acknowledgeManualDeparture()
+        updateViewportActionState(false)
         return
       }
       clearInitialScrollCancellation()
       clearHeadAnchor()
-      if (manualScrollActiveRef.current) return
-
       cancelLatestRecovery()
       manualScrollPausedRef.current = false
       clearNewMessageCount()
+      manualScrollDownRef.current = false
+      updateViewportActionState(true)
+      if (manualScrollActiveRef.current) return
     },
     [
       acknowledgeManualDeparture,
       cancelLatestRecovery,
       clearHeadAnchor,
       clearInitialScrollCancellation,
-      clearNewMessageCount
+      clearNewMessageCount,
+      updateViewportActionState
     ]
   )
 
@@ -358,18 +429,26 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
         return
       }
       manualScrollIntentRef.current = false
-      if (!manualScrollActiveRef.current) return
+      if (!manualScrollActiveRef.current) {
+        manualScrollDownRef.current = false
+        updateViewportActionState()
+        return
+      }
 
       manualScrollActiveRef.current = false
+      manualScrollDownRef.current = false
       const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : atBottomRef.current
-      if (!atBottom) return
+      if (!atBottom) {
+        updateViewportActionState(false)
+        return
+      }
 
       cancelLatestRecovery()
       atBottomRef.current = true
-      setIsAtBottom(true)
       manualScrollPausedRef.current = false
       clearHeadAnchor()
       clearNewMessageCount()
+      updateViewportActionState(true)
       runScrollCommand({ kind: 'follow-bottom' })
     },
     [
@@ -379,9 +458,21 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
       clearNewMessageCount,
       promoteManualScroll,
       runScrollCommand,
-      scrollParentRef
+      scrollParentRef,
+      updateViewportActionState
     ]
   )
+
+  const handleTotalListHeightChanged = useCallback(() => {
+    if (!scrollParentRef) return
+
+    const atBottom = isViewportAtBottom(scrollParentRef)
+    if (atBottom !== atBottomRef.current) {
+      handleAtBottomStateChange(atBottom)
+      return
+    }
+    updateViewportActionState(atBottom)
+  }, [handleAtBottomStateChange, scrollParentRef, updateViewportActionState])
 
   const handleFollowOutput = useCallback(
     (atBottom: boolean) =>
@@ -393,15 +484,39 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     manualScrollIntentRef.current = false
     manualScrollActiveRef.current = false
     manualScrollPausedRef.current = false
+    manualScrollDownRef.current = false
     latestRecoveryRef.current = true
     clearInitialScrollCancellation()
     clearHeadAnchor()
     clearNewMessageCount()
+    updateViewportActionState()
     runScrollCommand({ kind: 'follow-latest' })
-  }, [clearHeadAnchor, clearInitialScrollCancellation, clearNewMessageCount, runScrollCommand])
+  }, [
+    clearHeadAnchor,
+    clearInitialScrollCancellation,
+    clearNewMessageCount,
+    runScrollCommand,
+    updateViewportActionState
+  ])
 
-  const followActionLabel =
-    newMessageCount === 0 ? '回到底部' : `${newMessageCount > 99 ? '99+' : newMessageCount} 条新消息`
+  useLayoutEffect(() => {
+    if (localSendToken <= lastLocalSendTokenRef.current) return
+
+    lastLocalSendTokenRef.current = localSendToken
+    handleFollowLatest()
+  }, [handleFollowLatest, localSendToken])
+
+  const displayedNewMessageCount = Math.min(newMessageCount, 99)
+  const hasNewMessages = newMessageCount > 0
+  const followActionLabel = hasNewMessages
+    ? `${newMessageCount > 99 ? '99+' : newMessageCount} new message${newMessageCount === 1 ? '' : 's'}`
+    : 'Scroll to latest messages'
+  const isFollowActionVisible =
+    hasChildren &&
+    scrollParentRef !== null &&
+    !viewportActionState.isAtBottom &&
+    viewportActionState.isBeyondHalfScreen &&
+    !viewportActionState.isManualScrollDown
 
   return (
     <div className="relative min-h-0">
@@ -414,6 +529,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
             overscan={200}
             atBottomStateChange={handleAtBottomStateChange}
             isScrolling={handleIsScrolling}
+            totalListHeightChanged={handleTotalListHeightChanged}
             followOutput={isTailAppend ? handleFollowOutput : false}
             firstItemIndex={firstItemIndex}
             initialTopMostItemIndex={initialTopMostItemIndex}
@@ -425,16 +541,40 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
           />
         ) : null}
       </ScrollArea>
-      {hasChildren && scrollParentRef && !isAtBottom ? (
+      {hasChildren && scrollParentRef ? (
         <button
           type="button"
           aria-label={followActionLabel}
           title={followActionLabel}
-          className="bg-secondary absolute right-3 bottom-3 z-10 inline-flex h-7 items-center gap-x-1.5 rounded-full px-2 text-xs font-medium text-slate-500 shadow-sm hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+          aria-hidden={!isFollowActionVisible}
+          data-state={isFollowActionVisible ? 'open' : 'closed'}
+          data-testid="follow-latest-action"
+          disabled={!isFollowActionVisible}
+          tabIndex={isFollowActionVisible ? 0 : -1}
+          className={cn(
+            'bg-secondary absolute bottom-3 left-1/2 z-10 grid h-7 -translate-x-1/2 items-center overflow-hidden rounded-full text-xs font-medium text-slate-500 shadow-sm transition-[opacity,grid-template-columns,gap,padding] duration-200 ease-out hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none disabled:cursor-default dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700',
+            hasNewMessages ? 'grid-cols-[auto_1fr] gap-x-1.5 px-2' : 'grid-cols-[auto_0fr] gap-x-0 px-1.5',
+            isFollowActionVisible ? 'opacity-100' : 'pointer-events-none opacity-0'
+          )}
           onClick={handleFollowLatest}
         >
           <ArrowDownIcon size={14} aria-hidden="true" />
-          <span>{followActionLabel}</span>
+          {hasNewMessages ? (
+            <span className="min-w-0 overflow-hidden text-xs whitespace-nowrap">
+              {import.meta.env.FIREFOX ? (
+                <span className="tabular-nums">
+                  {displayedNewMessageCount}
+                  {newMessageCount > 99 ? '+' : ''}
+                </span>
+              ) : (
+                <span className="inline-flex tabular-nums">
+                  <NumberFlow value={displayedNewMessageCount} />
+                  {newMessageCount > 99 ? '+' : null}
+                </span>
+              )}{' '}
+              {newMessageCount === 1 ? 'new message' : 'new messages'}
+            </span>
+          ) : null}
         </button>
       ) : null}
     </div>

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -17,21 +17,21 @@ const itemKey = (_: number, item: ReactElement) => {
 }
 
 type ChildUpdate =
-  | { kind: 'initial' | 'none' | 'replace' }
+  | { update: 'initial' | 'none' | 'replace' }
   | {
-      kind: 'head' | 'tail'
+      update: 'head' | 'tail'
       count: number
     }
   | {
       headCount: number
-      kind: 'head-tail'
+      update: 'head-tail'
       tailCount: number
     }
 
 type ScrollCommand =
-  | { kind: 'cancel-initial'; top: number }
-  | { kind: 'follow-bottom' | 'follow-latest' }
-  | { index: number; kind: 'head-rebase'; offset: number }
+  | { command: 'cancel-initial'; top: number }
+  | { command: 'follow-bottom' | 'follow-latest' }
+  | { command: 'head-rebase'; index: number; offset: number }
 
 const hasPrefix = (prefix: readonly string[], values: readonly string[]) =>
   prefix.length <= values.length && prefix.every((value, index) => values[index] === value)
@@ -97,23 +97,23 @@ const getViewportActionState = (
 }
 
 const getChildUpdate = (previous: readonly string[] | null, current: readonly string[]): ChildUpdate => {
-  if (previous === null) return { kind: 'initial' }
-  if (hasSameItems(previous, current)) return { kind: 'none' }
+  if (previous === null) return { update: 'initial' }
+  if (hasSameItems(previous, current)) return { update: 'none' }
   if (current.length > previous.length && hasPrefix(previous, current)) {
-    return { kind: 'tail', count: current.length - previous.length }
+    return { update: 'tail', count: current.length - previous.length }
   }
   if (current.length > previous.length && hasSuffix(previous, current)) {
-    return { kind: 'head', count: current.length - previous.length }
+    return { update: 'head', count: current.length - previous.length }
   }
   if (current.length > previous.length) {
     for (let headCount = 1; headCount < current.length - previous.length; headCount += 1) {
       const tailCount = current.length - previous.length - headCount
       if (hasSameItems(previous, current.slice(headCount, headCount + previous.length))) {
-        return { kind: 'head-tail', headCount, tailCount }
+        return { update: 'head-tail', headCount, tailCount }
       }
     }
   }
-  return { kind: 'replace' }
+  return { update: 'replace' }
 }
 
 const INITIAL_FIRST_ITEM_INDEX = 1_000_000
@@ -157,9 +157,9 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
   const itemKeysRef = useRef<readonly string[]>(itemKeys)
   const childUpdate = useMemo(() => getChildUpdate(previousItemKeysRef.current, itemKeys), [itemKeys])
   const headCount =
-    childUpdate.kind === 'head' ? childUpdate.count : childUpdate.kind === 'head-tail' ? childUpdate.headCount : 0
+    childUpdate.update === 'head' ? childUpdate.count : childUpdate.update === 'head-tail' ? childUpdate.headCount : 0
   const tailCount =
-    childUpdate.kind === 'tail' ? childUpdate.count : childUpdate.kind === 'head-tail' ? childUpdate.tailCount : 0
+    childUpdate.update === 'tail' ? childUpdate.count : childUpdate.update === 'head-tail' ? childUpdate.tailCount : 0
   const isHeadPrepend = headCount > 0 && lastHeadItemKeysRef.current !== itemKeys
   const isTailAppend = tailCount > 0
   const isNewTailAppend = isTailAppend && lastTailItemKeysRef.current !== itemKeys
@@ -216,7 +216,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
     const handle = virtuosoRef.current
     if (!handle) return
 
-    switch (command.kind) {
+    switch (command.command) {
       case 'cancel-initial':
         handle.scrollTo({ top: command.top })
         return
@@ -242,7 +242,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
     if (!getVisibleItemLocation(scrollParentRef)) return
 
     initialScrollCancellationPendingRef.current = false
-    runScrollCommand({ kind: 'cancel-initial', top: scrollParentRef.scrollTop })
+    runScrollCommand({ command: 'cancel-initial', top: scrollParentRef.scrollTop })
     clearInitialScrollCancellation()
   }, [clearInitialScrollCancellation, runScrollCommand, scrollParentRef])
 
@@ -301,14 +301,14 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
       if (headAnchor) {
         const index = headAnchor.index + headCount
         if (itemKeys[index] === headAnchor.key) {
-          runScrollCommand({ kind: 'head-rebase', index, offset: headAnchor.offset })
+          runScrollCommand({ command: 'head-rebase', index, offset: headAnchor.offset })
         }
       }
     }
-    if (childUpdate.kind === 'tail' || childUpdate.kind === 'replace') {
+    if (childUpdate.update === 'tail' || childUpdate.update === 'replace') {
       clearInitialScrollCancellation()
     }
-    if (childUpdate.kind === 'replace') {
+    if (childUpdate.update === 'replace') {
       clearHeadAnchor()
       cancelLatestRecovery()
     }
@@ -395,7 +395,8 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
   ])
 
   const handleAtBottomStateChange = useCallback(
-    (atBottom: boolean) => {
+    (reportedAtBottom: boolean) => {
+      const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : reportedAtBottom
       atBottomRef.current = atBottom
       if (!atBottom) {
         acknowledgeManualDeparture()
@@ -449,7 +450,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
       clearHeadAnchor()
       clearNewMessageCount()
       updateViewportActionState(true)
-      runScrollCommand({ kind: 'follow-bottom' })
+      runScrollCommand({ command: 'follow-bottom' })
     },
     [
       acknowledgeManualDeparture,
@@ -490,7 +491,7 @@ const MessageList: FC<MessageListProps> = ({ children, localSendToken = 0 }) => 
     clearHeadAnchor()
     clearNewMessageCount()
     updateViewportActionState()
-    runScrollCommand({ kind: 'follow-latest' })
+    runScrollCommand({ command: 'follow-latest' })
   }, [
     clearHeadAnchor,
     clearInitialScrollCancellation,

--- a/src/app/content/components/message-list.tsx
+++ b/src/app/content/components/message-list.tsx
@@ -19,6 +19,11 @@ type ChildUpdate =
       kind: 'head' | 'tail'
       count: number
     }
+  | {
+      headCount: number
+      kind: 'head-tail'
+      tailCount: number
+    }
 
 type ScrollCommand =
   | { kind: 'cancel-initial'; top: number }
@@ -78,6 +83,14 @@ const getChildUpdate = (previous: readonly string[] | null, current: readonly st
   if (current.length > previous.length && hasSuffix(previous, current)) {
     return { kind: 'head', count: current.length - previous.length }
   }
+  if (current.length > previous.length) {
+    for (let headCount = 1; headCount < current.length - previous.length; headCount += 1) {
+      const tailCount = current.length - previous.length - headCount
+      if (hasSameItems(previous, current.slice(headCount, headCount + previous.length))) {
+        return { kind: 'head-tail', headCount, tailCount }
+      }
+    }
+  }
   return { kind: 'replace' }
 }
 
@@ -95,6 +108,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   const previousItemKeysRef = useRef<readonly string[] | null>(null)
   const firstItemIndexRef = useRef(INITIAL_FIRST_ITEM_INDEX)
   const lastHeadItemKeysRef = useRef<readonly string[] | null>(null)
+  const lastTailItemKeysRef = useRef<readonly string[] | null>(null)
   const atBottomRef = useRef(true)
   const manualScrollIntentRef = useRef(false)
   const manualScrollActiveRef = useRef(false)
@@ -103,6 +117,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   const initialScrollCancellationPendingRef = useRef(false)
   const initialScrollCancellationPassedHeadRef = useRef(false)
   const headAnchorRef = useRef<HeadAnchor | null>(null)
+  const latestRecoveryRef = useRef(false)
   const newMessageCountRef = useRef(0)
   const hasChildren = children !== null && children !== undefined
   const itemKeys = useMemo(
@@ -111,8 +126,14 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   )
   const itemKeysRef = useRef<readonly string[]>(itemKeys)
   const childUpdate = useMemo(() => getChildUpdate(previousItemKeysRef.current, itemKeys), [itemKeys])
-  const isHeadPrepend = childUpdate.kind === 'head' && lastHeadItemKeysRef.current !== itemKeys
-  const firstItemIndex = isHeadPrepend ? firstItemIndexRef.current - childUpdate.count : firstItemIndexRef.current
+  const headCount =
+    childUpdate.kind === 'head' ? childUpdate.count : childUpdate.kind === 'head-tail' ? childUpdate.headCount : 0
+  const tailCount =
+    childUpdate.kind === 'tail' ? childUpdate.count : childUpdate.kind === 'head-tail' ? childUpdate.tailCount : 0
+  const isHeadPrepend = headCount > 0 && lastHeadItemKeysRef.current !== itemKeys
+  const isTailAppend = tailCount > 0
+  const isNewTailAppend = isTailAppend && lastTailItemKeysRef.current !== itemKeys
+  const firstItemIndex = isHeadPrepend ? firstItemIndexRef.current - headCount : firstItemIndexRef.current
 
   const clearNewMessageCount = useCallback(() => {
     if (newMessageCountRef.current === 0) return
@@ -127,7 +148,8 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   }, [])
 
   const canFollowLatest = useCallback(
-    (atBottom: boolean) => atBottom && !manualScrollActiveRef.current && !manualScrollPausedRef.current,
+    (atBottom: boolean) =>
+      atBottom && !latestRecoveryRef.current && !manualScrollActiveRef.current && !manualScrollPausedRef.current,
     []
   )
 
@@ -138,6 +160,10 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
 
   const clearHeadAnchor = useCallback(() => {
     headAnchorRef.current = null
+  }, [])
+
+  const cancelLatestRecovery = useCallback(() => {
+    latestRecoveryRef.current = false
   }, [])
 
   const runScrollCommand = useCallback((command: ScrollCommand) => {
@@ -185,21 +211,27 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     promoteManualScroll()
     if (!manualScrollActiveRef.current) return
 
+    cancelLatestRecovery()
     atBottomRef.current = false
     manualScrollPausedRef.current = true
     setIsAtBottom(false)
     captureHeadAnchor()
     captureInitialScrollCancellation()
-  }, [captureHeadAnchor, captureInitialScrollCancellation, promoteManualScroll, scrollParentRef])
+  }, [cancelLatestRecovery, captureHeadAnchor, captureInitialScrollCancellation, promoteManualScroll, scrollParentRef])
 
   useLayoutEffect(() => {
     itemKeysRef.current = itemKeys
   }, [itemKeys])
 
   useLayoutEffect(() => {
-    if (childUpdate.kind === 'tail' && !canFollowLatest(atBottomRef.current)) {
-      newMessageCountRef.current += childUpdate.count
-      setNewMessageCount(newMessageCountRef.current)
+    if (isNewTailAppend) {
+      lastTailItemKeysRef.current = itemKeys
+      if (latestRecoveryRef.current) {
+        clearNewMessageCount()
+      } else if (!canFollowLatest(atBottomRef.current)) {
+        newMessageCountRef.current += tailCount
+        setNewMessageCount(newMessageCountRef.current)
+      }
     }
     if (isHeadPrepend) {
       firstItemIndexRef.current = firstItemIndex
@@ -214,7 +246,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
       const headAnchor = headAnchorRef.current
       clearHeadAnchor()
       if (headAnchor) {
-        const index = headAnchor.index + childUpdate.count
+        const index = headAnchor.index + headCount
         if (itemKeys[index] === headAnchor.key) {
           runScrollCommand({ kind: 'head-rebase', index, offset: headAnchor.offset })
         }
@@ -225,18 +257,25 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     }
     if (childUpdate.kind === 'replace') {
       clearHeadAnchor()
+      cancelLatestRecovery()
     }
     previousItemKeysRef.current = hasChildren ? itemKeys : null
   }, [
     canFollowLatest,
+    cancelLatestRecovery,
     childUpdate,
     clearHeadAnchor,
     clearInitialScrollCancellation,
+    clearNewMessageCount,
     firstItemIndex,
+    headCount,
     hasChildren,
     isHeadPrepend,
+    isNewTailAppend,
+    isTailAppend,
     itemKeys,
-    runScrollCommand
+    runScrollCommand,
+    tailCount
   ])
 
   useLayoutEffect(() => {
@@ -244,6 +283,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
 
     const scrollArea = scrollParentRef.closest<HTMLElement>('[data-slot="scroll-area"]') ?? scrollParentRef
     const markManualScrollIntent = () => {
+      cancelLatestRecovery()
       if (initialScrollCancellationEligibleRef.current) {
         initialScrollCancellationEligibleRef.current = false
         initialScrollCancellationPendingRef.current = true
@@ -274,9 +314,11 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
       scrollParentRef.removeEventListener('scroll', handleScroll)
       clearInitialScrollCancellation()
       clearHeadAnchor()
+      cancelLatestRecovery()
     }
   }, [
     acknowledgeManualDeparture,
+    cancelLatestRecovery,
     clearHeadAnchor,
     clearInitialScrollCancellation,
     promoteManualScroll,
@@ -295,10 +337,17 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
       clearHeadAnchor()
       if (manualScrollActiveRef.current) return
 
+      cancelLatestRecovery()
       manualScrollPausedRef.current = false
       clearNewMessageCount()
     },
-    [acknowledgeManualDeparture, clearHeadAnchor, clearInitialScrollCancellation, clearNewMessageCount]
+    [
+      acknowledgeManualDeparture,
+      cancelLatestRecovery,
+      clearHeadAnchor,
+      clearInitialScrollCancellation,
+      clearNewMessageCount
+    ]
   )
 
   const handleIsScrolling = useCallback(
@@ -315,6 +364,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
       const atBottom = scrollParentRef ? isViewportAtBottom(scrollParentRef) : atBottomRef.current
       if (!atBottom) return
 
+      cancelLatestRecovery()
       atBottomRef.current = true
       setIsAtBottom(true)
       manualScrollPausedRef.current = false
@@ -324,6 +374,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
     },
     [
       acknowledgeManualDeparture,
+      cancelLatestRecovery,
       clearHeadAnchor,
       clearNewMessageCount,
       promoteManualScroll,
@@ -333,14 +384,16 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
   )
 
   const handleFollowOutput = useCallback(
-    (atBottom: boolean) => (childUpdate.kind === 'tail' && canFollowLatest(atBottom) ? 'smooth' : false),
-    [canFollowLatest, childUpdate.kind]
+    (atBottom: boolean) =>
+      isTailAppend && ((isNewTailAppend && latestRecoveryRef.current) || canFollowLatest(atBottom)) ? 'smooth' : false,
+    [canFollowLatest, isNewTailAppend, isTailAppend]
   )
 
   const handleFollowLatest = useCallback(() => {
     manualScrollIntentRef.current = false
     manualScrollActiveRef.current = false
     manualScrollPausedRef.current = false
+    latestRecoveryRef.current = true
     clearInitialScrollCancellation()
     clearHeadAnchor()
     clearNewMessageCount()
@@ -361,7 +414,7 @@ const MessageList: FC<MessageListProps> = ({ children }) => {
             overscan={200}
             atBottomStateChange={handleAtBottomStateChange}
             isScrolling={handleIsScrolling}
-            followOutput={childUpdate.kind === 'tail' ? handleFollowOutput : false}
+            followOutput={isTailAppend ? handleFollowOutput : false}
             firstItemIndex={firstItemIndex}
             initialTopMostItemIndex={initialTopMostItemIndex}
             data={children}

--- a/src/app/content/views/footer/index.test.tsx
+++ b/src/app/content/views/footer/index.test.tsx
@@ -41,6 +41,7 @@ afterEach(() => {
   cleanup()
   vi.clearAllMocks()
   canSubmitText = false
+  queryFixtures['MessageInput.ValueQuery'] = 'hello'
 })
 
 const renderFooter = () => render(<Footer />)
@@ -110,5 +111,51 @@ describe('Footer step-4 submit gate', () => {
     pressEnter()
     await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledTimes(1))
     expect(sendSpy).toHaveBeenCalledWith(submitShape())
+  })
+
+  it('notifies the Document-local owner only after dispatching a valid text command', async () => {
+    const onLocalTextSent = vi.fn()
+    canSubmitText = true
+    render(<Footer onLocalTextSent={onLocalTextSent} />)
+
+    pressEnter()
+
+    await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledWith(submitShape()))
+    expect(onLocalTextSent).toHaveBeenCalledOnce()
+    expect(sendSpy.mock.invocationCallOrder[0]).toBeLessThan(onLocalTextSent.mock.invocationCallOrder[0]!)
+  })
+
+  it('does not notify the Document-local owner for a gated submit', () => {
+    const onLocalTextSent = vi.fn()
+    render(<Footer onLocalTextSent={onLocalTextSent} />)
+
+    pressEnter()
+
+    expect(onLocalTextSent).not.toHaveBeenCalled()
+  })
+
+  it('does not notify the Document-local owner for blank text', async () => {
+    const onLocalTextSent = vi.fn()
+    canSubmitText = true
+    queryFixtures['MessageInput.ValueQuery'] = '   '
+    render(<Footer onLocalTextSent={onLocalTextSent} />)
+
+    pressEnter()
+    await Promise.resolve()
+
+    expect(onLocalTextSent).not.toHaveBeenCalled()
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not notify the Document-local owner when byte validation rejects text', async () => {
+    const onLocalTextSent = vi.fn()
+    canSubmitText = true
+    queryFixtures['MessageInput.ValueQuery'] = 'x'.repeat(200_000)
+    render(<Footer onLocalTextSent={onLocalTextSent} />)
+
+    pressEnter()
+
+    await vi.waitFor(() => expect(sendSpy).toHaveBeenCalledWith('Toast.WarningCommand'))
+    expect(onLocalTextSent).not.toHaveBeenCalled()
   })
 })

--- a/src/app/content/views/footer/index.tsx
+++ b/src/app/content/views/footer/index.tsx
@@ -28,7 +28,11 @@ import { nanoid } from 'nanoid'
 import imgcap from 'imgcap'
 import useRoot from '@/hooks/useRoot'
 
-const Footer: FC = () => {
+export interface FooterProps {
+  onLocalTextSent?: () => void
+}
+
+const Footer: FC<FooterProps> = ({ onLocalTextSent }) => {
   const send = useRemeshSend()
   const toastDomain = useRemeshDomain(ToastDomain())
   const chatRoomDomain = useRemeshDomain(ChatRoomDomain())
@@ -161,6 +165,7 @@ const Footer: FC = () => {
     }
 
     send(chatRoomDomain.command.SendTextMessageCommand({ body: transformedMessage, mentions }))
+    onLocalTextSent?.()
   }
 
   const handleSend = useThrottle(handleSendMessage, 1000)

--- a/src/app/content/views/main/index.tsx
+++ b/src/app/content/views/main/index.tsx
@@ -11,7 +11,11 @@ import ChatRoomDomain from '@/domain/ChatRoom'
 import MessageListDomain from '@/domain/MessageList'
 import { compareEventPosition } from '@/domain/Message'
 
-const Main: FC = () => {
+export interface MainProps {
+  localSendToken: number
+}
+
+const Main: FC<MainProps> = ({ localSendToken }) => {
   const send = useRemeshSend()
   const messageListDomain = useRemeshDomain(MessageListDomain())
   const chatRoomDomain = useRemeshDomain(ChatRoomDomain())
@@ -40,7 +44,7 @@ const Main: FC = () => {
   )
 
   return (
-    <MessageList>
+    <MessageList localSendToken={localSendToken}>
       {messageListLoadFinished
         ? messageList.map((message, index) => {
             const key = messageRowKey(message)


### PR DESCRIPTION
## Message-list follow-latest repair

This Draft PR retains the six requested MessageList behavior corrections:

- Center the floating action within the message-list content area.
- Show ArrowDown when there are no unread messages; otherwise show English 1 / n / 99+ message labels.
- Preserve button fade and label-width transition lifecycles.
- Hide during real manual downward scrolling and restore after it stops when still eligible.
- Force follow after a local successful text send without allowing received or tail-sync updates to interrupt manual browsing.
- Show the action only when remaining distance exceeds half of the current viewport height.

## Live bottom snapshot repair

The stale-callback repair remains in place. This child also fixes the hosted N1 ordering defect: when a custom scroll parent exists, tail unread counting and `followOutput` both use the current physical viewport bottom snapshot. Virtuoso callback state is used only without a custom parent, so a physically off-bottom N1 cannot be followed instead of counted.

## Verification

- task #1660 independent review: CODE FINAL PASS 0/0/0.
- task #1661 independent review: CODE FINAL PASS 0/0/0.
- Node v24.19.0 local gates: focused unit 30/30, focused Chromium browser 13/13, full suite 85/85 files and 1094/1094 tests, check, format check, and diff check.
- Exact head: 9eddeb8ce5b15ec4437ae3be61630d4c9ad96314.

This PR remains Draft pending automatic exact-head CI and Owner re-acceptance.
