### PR TITLE
fix(runtime): retire incomplete rooms on recovery guard rejection

### DIFF
--- a/src/runtime/RemoteRoomTransport.test.ts
+++ b/src/runtime/RemoteRoomTransport.test.ts
@@ -523,4 +523,36 @@ describe('RemoteRoomTransport', () => {
     expect(closes).toEqual(['room-a'])
     await expect(transport.send('room-a', 'late')).rejects.toThrow('no current handle')
   })
+
+  it('commits no projection from a rejected rebind and the next explicit rebind enters a fresh accepting generation', async () => {
+    const fixture = createService()
+    const transport = new RemoteRoomTransport(fixture.service)
+    const messages: string[] = []
+    const closes: string[] = []
+    transport.onMessage((_roomId, _sourcePeerId, payload) => messages.push(payload))
+    transport.onRoomClose((roomId) => closes.push(roomId))
+
+    await transport.rebind()
+    transport.activateIngress()
+    await transport.join('room-a')
+
+    // The failed attempt rejects before any replacement reservation or completion exists:
+    // the facade retains its previous projection and admits no ingress from it.
+    vi.mocked(fixture.service.rebind).mockRejectedValueOnce(new Error('Transport Room recovery is incomplete'))
+    await expect(transport.rebind()).rejects.toThrow('Transport Room recovery is incomplete')
+    expect(transport.peerIdOf('room-a')).toBe('peer:room-a')
+    expect(fixture.service.join).toHaveBeenCalledTimes(1)
+
+    // The next explicit attempt does not reuse the failure: it commits a fresh projection and
+    // reaches the normal accepting state.
+    fixture.rooms.clear()
+    fixture.rooms.set('room-b', { roomId: 'room-b', handle: 'handle-b', peerId: 'peer:room-b' })
+    await transport.rebind()
+    transport.activateIngress()
+
+    expect(closes).toEqual(['room-a'])
+    expect(transport.peerIdOf('room-b')).toBe('peer:room-b')
+    fixture.messageCallbacks.at(-1)!('room-b', 'handle-b', 'peer-a', 'ready')
+    expect(messages).toEqual(['ready'])
+  })
 })

--- a/src/runtime/TransportHost.test.ts
+++ b/src/runtime/TransportHost.test.ts
@@ -177,6 +177,100 @@ describe('Offscreen TransportService', () => {
     ).rejects.toThrow('recovery is incomplete')
   })
 
+  it('retires only the exact incomplete current Room before rejecting, so the next rebind enters a clean generation', async () => {
+    const fixture = createTransport()
+    const retire = vi.fn(async (_roomIds: readonly string[]) => {})
+    fixture.transport.retireRoomsForPreparation = retire
+    const service = createTransportService(fixture.transport)
+    const binding = await service.rebind(
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      () => {}
+    )
+    const worldRoomId = getWorldRoomId()
+    await service.join(worldRoomId, 'handle-world', binding.admission)
+    await service.requireRoomRecovery('room-a', 'https://example.com', binding.admission)
+    await service.join('room-a', 'handle-a', binding.admission)
+    await service.join('room-b', 'handle-b', binding.admission)
+
+    await expect(
+      service.rebind(
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    ).rejects.toThrow('Transport Room recovery is incomplete')
+    expect(retire).toHaveBeenCalledExactlyOnceWith(['room-a'])
+
+    // The failure terminal retired only room-a; World and the unrelated Room survive, and the
+    // matching requirement/receipt are gone, so the next explicit rebind enters a clean cut.
+    const clean = await service.rebind(
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      () => {}
+    )
+    expect(clean.rooms).toEqual([
+      { roomId: worldRoomId, handle: 'handle-world', peerId: `peer:${worldRoomId}` },
+      { roomId: 'room-b', handle: 'handle-b', peerId: 'peer:room-b' }
+    ])
+    expect(clean.roomRecovery.rooms).toEqual([])
+    await expect(
+      service.rebind(
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        () => {}
+      )
+    ).resolves.toBeDefined()
+  })
+
+  it('does not retire a successor handle installed before the failure cleanup settles', async () => {
+    const fixture = createTransport()
+    let releaseRetire!: () => void
+    const retire = vi.fn(
+      (_roomIds: readonly string[]) =>
+        new Promise<void>((resolve) => {
+          releaseRetire = resolve
+        })
+    )
+    fixture.transport.retireRoomsForPreparation = retire
+    const service = createTransportService(fixture.transport)
+    const binding = await service.rebind(
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      () => {}
+    )
+    await service.requireRoomRecovery('room-a', 'https://example.com', binding.admission)
+    await service.join('room-a', 'handle-a', binding.admission)
+
+    const failing = service.rebind(
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      () => {}
+    )
+    await vi.waitFor(() => expect(retire).toHaveBeenCalledWith(['room-a']))
+    // The provider closes the observed handle and a successor is installed before the
+    // retirement terminal settles; cleanup must not cut the successor.
+    fixture.emit.close('room-a')
+    await service.join('room-a', 'handle-b', binding.admission)
+    releaseRetire()
+    await expect(failing).rejects.toThrow('Transport Room recovery is incomplete')
+
+    await expect(service.send('room-a', 'handle-b', 'payload')).resolves.toBeUndefined()
+    expect(fixture.transport.send).toHaveBeenCalledWith('room-a', 'payload', undefined)
+  })
+
   it('recovers only validated current sessions and fences a late prior-host write', async () => {
     const fixture = createTransport()
     const service = createTransportService(fixture.transport)

--- a/src/runtime/TransportHost.ts
+++ b/src/runtime/TransportHost.ts
@@ -399,10 +399,23 @@ export const createTransportService = (transport: RoomTransport = createRoomTran
         }
         const preCutFrames = [...pendingFrames.values()]
         if (preCutFrames.length > 0) await Promise.allSettled(preCutFrames.map((frame) => frame.task))
-        const incompleteRoom = [...roomRecoveryRequirements.keys()].find(
+        const incompleteRooms = [...roomRecoveryRequirements.keys()].filter(
           (roomId) => rooms.has(roomId) && !roomRecoveries.has(roomId)
         )
-        if (incompleteRoom) throw new Error('Transport Room recovery is incomplete')
+        if (incompleteRooms.length > 0) {
+          // Retire only each exact currently-owned incomplete physical Room through the same
+          // ownership cut as retireRoomForPreparation before rejecting the original error.
+          for (const roomId of incompleteRooms) {
+            const handle = rooms.get(roomId)?.handle
+            if (handle === undefined) continue
+            currentRoom(roomId, handle)
+            await transport.retireRoomsForPreparation([roomId])
+            // A provider close event may already have removed this handle. Otherwise retirement
+            // owns the local routing cut only after the exact provider terminal succeeded.
+            if (rooms.get(roomId)?.handle === handle) forgetRoom(roomId)
+          }
+          throw new Error('Transport Room recovery is incomplete')
+        }
         const current = projection()
         current.recoveryFrames = preCutFrames
           .filter(


### PR DESCRIPTION
Repairs the same-ROOM recovery failure terminal on exact 61126aaf.\n\n- Preserves the fail-closed guard and original error.\n- Retires only the exact current incomplete Room before rejection.\n- Leaves World, unrelated Rooms, and successor handles intact.\n\nLocal evidence: focused 26/26; runtime 395/395; check/format/diff passed. Full/OpenSpec caveats are unchanged baselines documented in the receipt.\n\nRaw patch SHA-256: 8e44cf037df6bfe29a4af381dafe8f0480eb95b5f55ee0ffb6e455f28db25e8f

## Owner acceptance
- Owner product acceptance: PASS for the AppButton/Room recovery flow on exact `61126aaf`; closure authorized.

