### PR TITLE
docs(readme): mark Trystero as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ WebChat builds on these excellent open-source projects:
 - **[WXT](https://wxt.dev/)** provides the cross-browser extension framework and build tooling.
 - **[Comctx](https://github.com/molvqingtai/comctx)** provides RPC communication across the extension's JavaScript contexts.
 - **[Artico](https://github.com/matallui/artico)** provides the default WebRTC room transport.
-- **[Trystero](https://github.com/dmotz/trystero)** remains a supported WebRTC room transport using its default Nostr strategy.
+- **[Trystero](https://github.com/dmotz/trystero)** provides an optional WebRTC room transport using its default Nostr strategy.
 - **[ugly-avatar](https://github.com/txstc55/ugly-avatar)** generates WebChat's distinctive random avatars.
 
 ## License

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,7 +51,7 @@ WebChat 建立在以下优秀的开源项目之上：
 - **[WXT](https://wxt.dev/)** 提供了跨浏览器扩展框架与构建工具。
 - **[Comctx](https://github.com/molvqingtai/comctx)** 提供了扩展各 JavaScript 上下文之间的 RPC 通信能力。
 - **[Artico](https://github.com/matallui/artico)** 提供默认的 WebRTC 房间传输。
-- **[Trystero](https://github.com/dmotz/trystero)** 仍是受支持的 WebRTC 房间传输，并使用其默认的 Nostr 策略。
+- **[Trystero](https://github.com/dmotz/trystero)** 提供可选的 WebRTC 房间传输，并使用其默认的 Nostr 策略。
 - **[ugly-avatar](https://github.com/txstc55/ugly-avatar)** 生成了 WebChat 独具特色的随机头像。
 
 ## 许可证


### PR DESCRIPTION
## Summary
- describe Trystero as an optional WebRTC room transport in both English and Chinese READMEs
- retain its default Nostr strategy detail
- keep Artico documented as the default transport

## Validation
- git diff --check
- hosted CI run 33257371283: setup / linter / tests / build all successful
- Owner copy acceptance: PASS

## Scope
- docs only; no runtime behavior change